### PR TITLE
Move Ruby devroom, Rubyfuza and RubyConf Australia from current to past

### DIFF
--- a/_data/current.yml
+++ b/_data/current.yml
@@ -1,25 +1,3 @@
-- name: Ruby devroom at FOSDEM
-  location: Brussels, Belgium
-  dates: "January 31, 2016"
-  url: http://fosdem.rubybelgium.be/
-  twitter: ruby_fosdem
-  cfp_phrase: CFP is open
-
-- name: Rubyfuza
-  location: Cape Town, South Africa
-  dates: "February 4-5, 2016"
-  url: http://www.rubyfuza.org
-  twitter: rubyfuza
-  reg_phrase: Registration is open
-  cfp_phrase: CFP is open
-
-- name: RubyConf Australia
-  location: Gold Coast, Australia
-  dates: "February 10-13, 2016"
-  url: http://www.rubyconf.org.au/2016
-  twitter: rubyconf_au
-  reg_phrase: Registration is open
-
 - name: Bath Ruby Conference
   location: Bath, UK
   dates: "March 11, 2016"

--- a/_data/past.yml
+++ b/_data/past.yml
@@ -600,3 +600,21 @@
   dates: "December 11-13, 2015"
   url: http://rubykaigi.org/2015
   twitter: rubykaigi
+
+- name: Ruby devroom at FOSDEM
+  location: Brussels, Belgium
+  dates: "January 31, 2016"
+  url: http://fosdem.rubybelgium.be/
+  twitter: ruby_fosdem
+
+- name: Rubyfuza
+  location: Cape Town, South Africa
+  dates: "February 4-5, 2016"
+  url: http://www.rubyfuza.org
+  twitter: rubyfuza
+
+- name: RubyConf Australia
+  location: Gold Coast, Australia
+  dates: "February 10-13, 2016"
+  url: http://www.rubyconf.org.au/2016
+  twitter: rubyconf_au


### PR DESCRIPTION
I moved the first three conferences from `current` to `past`, I am not sure if this is correct though.
Since it has already happened I imagine that the first conference should be the next one, if `CURRENT` means current year :smile: I'll just update this PR removing the phrases like `Registration/CFP is open`