### PR TITLE
Add Euruko 2016 to the list of conferences

### DIFF
--- a/_data/current.yml
+++ b/_data/current.yml
@@ -94,6 +94,12 @@
   url: http://www.windycityrails.org/
   twitter: windycityrails
 
+- name: EuRuKo
+  location: Sofia, Bulgaria
+  dates: "September 23-24, 2016"
+  url: http://euruko2016.org/
+  twitter: euruko
+
 - name: RubyConf
   location: Cincinnati, OH
   dates: "November 10-12, 2016"


### PR DESCRIPTION
Hello, 
I would like to add EuRuKo 2016 to the list of Ruby conferences.
