### PR TITLE
Update link to RubyConfBY, use english version

### DIFF
--- a/_data/current.yml
+++ b/_data/current.yml
@@ -55,7 +55,7 @@
 - name: RubyConfBY
   location: Minsk, Belarus
   dates: "April 24, 2016"
-  url: http://rubyconference.by/
+  url: http://rubyconference.by/en/
   twitter: rubyconfby
   reg_phrase: Registration is open
 


### PR DESCRIPTION
Sorry, just realized that it's probably better to have link to english version of conf website here.