### PR TITLE
Fixes RubyConf PT info

### DIFF
--- a/_data/current.yml
+++ b/_data/current.yml
@@ -111,11 +111,12 @@
   twitter: railsclub_ru
   cfp_phrase: CFP is open
 
-- name: RubyConf
+- name: RubyConf Portugal
   location: Braga, Portugal
   dates: "October 28-29, 2016"
   url: http://rubyconf.pt/
   twitter: rubyconfpt
+  reg_phrase: Registration is open
   cfp_phrase: CFP is open
 
 - name: RubyConf


### PR DESCRIPTION
Adds "Portugal" to the name, and registration open notice