### PR TITLE
Add Rocky Mountain Ruby 2016 to Current

### DIFF
--- a/_data/current.yml
+++ b/_data/current.yml
@@ -83,6 +83,14 @@
   url: http://www.windycityrails.org/
   twitter: windycityrails
 
+- name: Rocky Mountain Ruby
+  location: Boulder, CO
+  dates: "September 21-23, 2016"
+  url: http://rockymtnruby.com/
+  twitter: rockymtnruby
+  reg_phrase: Registration is open
+  cfp_phrase: CFP is open
+
 - name: EuRuKo
   location: Sofia, Bulgaria
   dates: "September 23-24, 2016"


### PR DESCRIPTION
Adds Rocky Mountain Ruby Conference in Boulder, CO Sep 21 - 23 2016 to Current