### PR TITLE
Update RubyConf Colombia 2016

### DIFF
--- a/_data/current.yml
+++ b/_data/current.yml
@@ -75,7 +75,6 @@
   url: http://www.rubyconf.co/
   twitter: rubyconfco
   reg_phrase: Registration is open
-  cfp_phrase: CFP is open
 
 - name: RubyKaigi
   location: Kyoto, Japan


### PR DESCRIPTION
Call for Papers closed on June 10, 2016