### PR TITLE
Updates RubyConf PT dates

### DIFF
--- a/_data/current.yml
+++ b/_data/current.yml
@@ -96,7 +96,7 @@
 
 - name: RubyConf Portugal
   location: Braga, Portugal
-  dates: "October 28-29, 2016"
+  dates: "October 27-28, 2016"
   url: http://rubyconf.pt/
   twitter: rubyconfpt
   reg_phrase: Registration is open


### PR DESCRIPTION
Why:

For logistical reasons, we had to move the conference to one day earlier.