### PR TITLE
Add Registration is Open to WindyCityRails.

### DIFF
--- a/_data/current.yml
+++ b/_data/current.yml
@@ -38,6 +38,7 @@
   dates: "September 15-16, 2016"
   url: http://www.windycityrails.org/
   twitter: windycityrails
+  reg_phrase: Registration is open
 
 - name: Rocky Mountain Ruby
   location: Boulder, CO


### PR DESCRIPTION
Registration is open for WindyCityRails, so let's all have a party and celebrate. Thanks, Jon for creating this centralized resource for Ruby conference enthusiasts!