### PR TITLE
Check for bonus keys

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -1,4 +1,4 @@
-messages = {
+error_messages = {
   1 => 'Jekyll failed to build site',
   2 => 'htmlproofer found errors',
   3 => 'Incomplete event data found',
@@ -10,11 +10,11 @@ messages = {
 
 system 'bundle exec rake'
 
-fail message if message = messages[$?.exitstatus]
+fail message if message = error_messages[$?.exitstatus]
 
 for commit in git.commits
   (subject, empty_line, *body) = commit.message.split("\n")
-  fail messages[5] if subject.length > 50
-  fail messages[6] if subject.split('').last == '.'
-  fail messages[7] if empty_line && empty_line.length > 0
+  fail error_messages[5] if subject.length > 50
+  fail error_messages[6] if subject.split('').last == '.'
+  fail error_messages[7] if empty_line && empty_line.length > 0
 end

--- a/Dangerfile
+++ b/Dangerfile
@@ -2,10 +2,11 @@ error_messages = {
   1 => 'Jekyll failed to build site',
   2 => 'htmlproofer found errors',
   3 => 'Incomplete event data found',
-  4 => 'Events out of order',
-  5 => 'Limit commit subject line to 50 characters',
-  6 => 'No period at end of commit subject',
-  7 => 'Separate subject from body with newline',
+  4 => 'Invalid event data found',
+  5 => 'Events out of order',
+  6 => 'Limit commit subject line to 50 characters',
+  7 => 'No period at end of commit subject',
+  8 => 'Separate subject from body with newline',
 }
 
 system 'bundle exec rake'
@@ -14,7 +15,7 @@ fail message if message = error_messages[$?.exitstatus]
 
 for commit in git.commits
   (subject, empty_line, *body) = commit.message.split("\n")
-  fail error_messages[5] if subject.length > 50
-  fail error_messages[6] if subject.split('').last == '.'
-  fail error_messages[7] if empty_line && empty_line.length > 0
+  fail error_messages[6] if subject.length > 50
+  fail error_messages[7] if subject.split('').last == '.'
+  fail error_messages[8] if empty_line && empty_line.length > 0
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,39 @@
 #!/usr/bin/env rake
 require 'yaml'
 
+class DataFileValidator
+  attr_accessor :events
+
+  def self.validate(events)
+    new(events).tap &:validate
+  end
+
+  def initialize(events)
+    @events = events
+  end
+
+  def validate
+    for event in events
+      missing_keys = required_keys - event.keys
+      unless missing_keys.empty?
+        puts "Missing keys: #{missing_keys}"
+        puts event
+        @missing_keys_error = true
+      end
+    end
+  end
+
+  def missing_keys?
+    @missing_keys_error
+  end
+
+  private
+
+  def required_keys
+    ["dates", "name", "location"]
+  end
+end
+
 desc "Build Jekyll site"
 task :build do
   exit 1 unless system "bundle exec jekyll build"
@@ -13,22 +46,22 @@ end
 
 desc "Verify event data"
 task :verify_data do
-  data_files = [:past, :current]
-  events = data_files.map { |file| YAML.load File.read "_data/#{file}.yml" }.flatten
+  data_files = [
+    {
+      filename: :past
+    }, {
+      filename: :current
+    }
+  ]
 
-  required_keys = ["dates", "name", "location"]
-  missing_keys_error = false
-  for event in events
-    missing_keys = required_keys - event.keys
-    unless missing_keys.empty?
-      puts "Missing keys: #{missing_keys}"
-      puts event
-      missing_keys_error = true
-    end
+  validators = data_files.map do |data_file|
+    data = YAML.load File.read "_data/#{data_file[:filename]}.yml"
+    DataFileValidator.validate(data)
   end
 
-  exit 3 if missing_keys_error
+  exit 3 if validators.any? &:missing_keys?
 
+  events = validators.map(&:events).flatten
   dates = events.map { |event| Date.parse event["dates"].gsub(/[-&][^,]+/, '') }
   exit 4 unless dates.sort == dates
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,50 +1,6 @@
 #!/usr/bin/env rake
 require 'yaml'
-
-class DataFileValidator
-  attr_accessor :events
-
-  def self.validate(events, allowed_keys)
-    new(events, allowed_keys).tap &:validate
-  end
-
-  def initialize(events, allowed_keys)
-    @events = events
-    @allowed_keys = allowed_keys
-  end
-
-  def validate
-    for event in events
-      missing_keys = required_keys - event.keys
-      unless missing_keys.empty?
-        puts "Missing keys: #{missing_keys}"
-        puts event
-        @missing_keys_error = true
-      end
-
-      bonus_keys = event.keys - @allowed_keys
-      unless bonus_keys.empty?
-        puts "Bonus keys: #{bonus_keys}"
-        puts event
-        @bonus_keys_error = true
-      end
-    end
-  end
-
-  def missing_keys?
-    @missing_keys_error
-  end
-
-  def bonus_keys?
-    @bonus_keys_error
-  end
-
-  private
-
-  def required_keys
-    ["dates", "name", "location"]
-  end
-end
+require './data_file_validator'
 
 desc "Build Jekyll site"
 task :build do

--- a/_config.yml
+++ b/_config.yml
@@ -9,5 +9,6 @@ exclude:
   - LICENSE.md
   - README.md
   - Rakefile
+  - data_file_validator.rb
   - notes.txt
   - vendor

--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,13 @@
 safe: true
 lsi: false
 source: .
-exclude: [CNAME, Dangerfile, Gemfile, Gemfile.lock, LICENSE.md, README.md, Rakefile, notes.txt, vendor]
+exclude:
+  - CNAME
+  - Dangerfile
+  - Gemfile
+  - Gemfile.lock
+  - LICENSE.md
+  - README.md
+  - Rakefile
+  - notes.txt
+  - vendor

--- a/data_file_validator.rb
+++ b/data_file_validator.rb
@@ -1,0 +1,44 @@
+class DataFileValidator
+  attr_accessor :events
+
+  def self.validate(events, allowed_keys)
+    new(events, allowed_keys).tap &:validate
+  end
+
+  def initialize(events, allowed_keys)
+    @events = events
+    @allowed_keys = allowed_keys
+  end
+
+  def validate
+    for event in events
+      missing_keys = required_keys - event.keys
+      unless missing_keys.empty?
+        puts "Missing keys: #{missing_keys}"
+        puts event
+        @missing_keys_error = true
+      end
+
+      bonus_keys = event.keys - @allowed_keys
+      unless bonus_keys.empty?
+        puts "Bonus keys: #{bonus_keys}"
+        puts event
+        @bonus_keys_error = true
+      end
+    end
+  end
+
+  def missing_keys?
+    @missing_keys_error
+  end
+
+  def bonus_keys?
+    @bonus_keys_error
+  end
+
+  private
+
+  def required_keys
+    ["dates", "name", "location"]
+  end
+end


### PR DESCRIPTION
This PR aims to improve Danger's ability to find easy data mistakes - in this case when bonus keys have been added to the data files. What will often happen is that a PR moves events from the current list to the past list, but includes keys like `reg_phrase`, which aren't supposed to be in the past file. Danger can now catch this and alert the committer.

While I was at it, I also now enforce a list of allowed keys in either file, something that I will document in the README in a subsequent commit.