### PR TITLE
Fix RubyConf Brazil URL

### DIFF
--- a/_data/current.yml
+++ b/_data/current.yml
@@ -36,7 +36,7 @@
 - name: RubyConf Brazil
   location: São Paulo, Brazil
   dates: "September 23-24, 2016"
-  url: http://rubyconfbrcfp.com.br/
+  url: http://www.rubyconf.com.br/
   twitter: rubyconfbr
   reg_phrase: Registration is open
 


### PR DESCRIPTION
The old url was only for the 'call for proposals'.