### PR TITLE
Add RedDotRubyConf

### DIFF
--- a/_data/current.yml
+++ b/_data/current.yml
@@ -61,3 +61,11 @@
   twitter: railsconf
   cfp_phrase: CFP closes
   cfp_date: "January 20, 2017"
+
+- name: RedDotRubyConf
+  location: Singapore
+  dates: "June 22-23, 2017"
+  url: http://www.reddotrubyconf.com/
+  twitter: reddotrubyconf
+  cfp_phrase: CFP closes
+  cfp_date: "March 15, 2017"


### PR DESCRIPTION
Source: https://rdrc-cfp-app.herokuapp.com/

It would be a little bit confusing though, because the official page is not updated and it doesn't link to the above CFP page. Maybe we should add a new field - `cfp_url` and link to it if it's present?