### PR TITLE
Change RedDotRubyConf URL to current CFP

### DIFF
--- a/_data/current.yml
+++ b/_data/current.yml
@@ -73,7 +73,7 @@
 - name: RedDotRubyConf
   location: Singapore
   dates: "June 22-23, 2017"
-  url: http://www.reddotrubyconf.com/
+  url: https://cfp.reddotrubyconf.com/
   twitter: reddotrubyconf
   cfp_phrase: CFP closes
   cfp_date: "March 15, 2017"


### PR DESCRIPTION
Link to CFP URL for RDRC 2017, instead of conference link from 2016