### PR TITLE
Add RubyWorld 2017 conf, w/ temp URL

### DIFF
--- a/_data/current.yml
+++ b/_data/current.yml
@@ -91,6 +91,12 @@
   cfp_phrase: CFP Closes
   cfp_date: "April 1, 2017"
 
+- name: RubyWorld Conference
+  location: Matsue, Shimane, Japan
+  dates: "November 1-2, 2017"
+  url: http://2016.rubyworld-conf.org/en/news/2017/01/rwc2017/
+  twitter: RubyWorldConf
+
 - name: RailsIsrael
   location: Tel Aviv, Israel
   dates: "November 28-30, 2017"

--- a/_data/current.yml
+++ b/_data/current.yml
@@ -94,7 +94,7 @@
 - name: RubyWorld Conference
   location: Matsue, Shimane, Japan
   dates: "November 1-2, 2017"
-  url: http://2016.rubyworld-conf.org/en/news/2017/01/rwc2017/
+  url: "http://2016.rubyworld-conf.org/en/news/2017/01/rwc2017/"
   twitter: RubyWorldConf
 
 - name: RailsIsrael


### PR DESCRIPTION
I can't find a canonical longer-term URL for this conference so I used the announcement URL on their 2016 site.