### PR TITLE
Remove RuLu from current conference schedule

### DIFF
--- a/_data/current.yml
+++ b/_data/current.yml
@@ -37,13 +37,6 @@
   cfp_phrase: CFP closes
   cfp_date: "April 21, 2017"
 
-- name: RuLu
-  location: Lyon, France
-  dates: "June 22-23, 2017"
-  url: http://rulu.eu/
-  twitter: rulu
-  cfp_phrase: CFP open
-
 - name: RedDotRubyConf
   location: Singapore
   dates: "June 22-23, 2017"


### PR DESCRIPTION
RuLu announced this morning that they're on hiatus until an undecided date in the fall.

buff.ly/2oXmGVy