### PR TITLE
Remove 2014 Scottish Ruby Conf schedule link

### DIFF
--- a/_data/past.yml
+++ b/_data/past.yml
@@ -101,7 +101,6 @@
   dates: "May 12-13, 2014"
   url: http://scottishrubyconference.com
   twitter: scotrubyconf
-  video_link: http://programme2014.scottishrubyconference.com/schedule
 
 - name: RubyConf Uruguay
   location: Montevideo, Uruguay


### PR DESCRIPTION
the link is 502'ing, and blocking Travis checks. I'm not sure removing is the /right/ solution but it fixes the problem?