### PR TITLE
Allow more recent ruby versions with specifier

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-ruby '2.3.1'
+ruby '~> 2.3.1'
 #ruby-gemset=ruby-conferences
 
 gem 'danger'


### PR DESCRIPTION
You may need to update your bundler version to use the ruby version specifier.

https://devcenter.heroku.com/articles/ruby-versions#ruby-version-specifiers