### PR TITLE
Kiwi Ruby registration is open

### DIFF
--- a/_data/current.yml
+++ b/_data/current.yml
@@ -81,6 +81,7 @@
   dates: "November 2-3, 2017"
   url: http://kiwi.ruby.nz
   twitter: kiwirubyconf
+  reg_phrase: Registration is open
 
 - name: RubyConf
   location: New Orleans, LA


### PR DESCRIPTION
Hello! Kiwi Ruby registration is open :sparkles: and has been for a while actually, just forgot to update this