### PR TITLE
Update RubyKaigi, which is changing dates

### DIFF
--- a/_data/current.yml
+++ b/_data/current.yml
@@ -11,13 +11,6 @@
   url: http://rubyconfchina.org
   reg_phrase: Registration is open
 
-- name: RubyKaigi
-  location: Hiroshima, Japan
-  dates: "September 18-20, 2017"
-  url: http://rubykaigi.org/2017
-  twitter: rubykaigi
-  reg_phrase: Registration is open
-
 - name: RailsClub
   location: Moscow, Russia
   dates: "September 23, 2017"
@@ -106,6 +99,12 @@
   dates: "March 22-23, 2018"
   url: http://2018.bathruby.uk
   twitter: bathruby
+
+- name: RubyKaigi
+  location: Sendai, Japan
+  dates: "May 31st-June 2nd, 2018"
+  url: http://rubykaigi.org/2018
+  twitter: rubykaigi
 
 - name: Brighton Ruby Conference
   location: Brighton, UK

--- a/_data/past.yml
+++ b/_data/past.yml
@@ -931,3 +931,9 @@
   dates: "Aug 12, 2017"
   url: http://www.deccanrubyconf.org/
   twitter: deccanrubyconf
+
+- name: RubyKaigi
+  location: Hiroshima, Japan
+  dates: "September 18-20, 2017"
+  url: http://rubykaigi.org/2017
+  twitter: rubykaigi


### PR DESCRIPTION
RubyKaigi 2017 is over. But RubyKaigi 2018 is (unexpectedly) changing what time of year they have it starting in 2018. Doesn't look like the CfP is open yet.