### PR TITLE
Only check external links in Travis cron jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ language: ruby
 rvm:
   - 2.4.2
 script:
-  - bundle exec danger
+  - ./bin/travis_script
 env:
   global:
     - NOKOGIRI_USE_SYSTEM_LIBRARIES=true

--- a/Dangerfile
+++ b/Dangerfile
@@ -6,7 +6,7 @@ error_messages = {
   5 => 'Events out of order'
 }
 
-system 'bundle exec rake'
+system 'bundle exec rake build verify_data'
 
 fail message if message = error_messages[$?.exitstatus]
 

--- a/bin/travis_script
+++ b/bin/travis_script
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+if [ "${TRAVIS_EVENT_TYPE}" = "cron" ]; then
+  bundle exec rake build verify_data verify_html
+else
+  bundle exec danger
+fi


### PR DESCRIPTION
I really do want to know when links on the site are broken, but htmlproofer has become noise that I ignore on PRs, so I'm trying something new. I've setup Travis to run a daily build and added configuration here so that the entire test suite will be run during that job.

On PRs, the step of checking external links is skipped.