### PR TITLE
Updated RubyConf India CFP date

### DIFF
--- a/_data/current.yml
+++ b/_data/current.yml
@@ -37,7 +37,7 @@
   url: http://rubyconfindia.org
   twitter: RubyConfIndia
   cfp_phrase: CFP closes
-  cfp_date: "November 30, 2017"
+  cfp_date: "December 15, 2017"
 
 - name: RubyConf AU
   location: Sydney, Australia


### PR DESCRIPTION
RubyConf India has changed [CFP](https://www.papercall.io/rci18) closing date to December 15, 2017.