### PR TITLE
Add RailsConf and RubyConf

### DIFF
--- a/_data/current.yml
+++ b/_data/current.yml
@@ -52,6 +52,14 @@
   cfp_phrase: CFP closes
   cfp_date: "Feb 4, 2018"
 
+- name: RailsConf
+  location: Pittsburgh, PA
+  dates: "April 17-19, 2018"
+  url: https://railsconf.com/
+  twitter: railsconf
+  cfp_phrase: CFP closes
+  cfp_date: "Jan 19, 2018"
+  
 - name: Ruby X Elixir Conf Taiwan
   location: Taipei, Taiwan
   dates: "April 27-28th, 2018"
@@ -101,3 +109,10 @@
   dates: "July 6, 2018"
   url: http://brightonruby.com/
   twitter: brightonruby
+
+- name: RubyConf
+  location: Los Angeles, CA
+  dates: "November 13-15, 2018"
+  url: https://rubyconf.org/
+  twitter: rubyconf
+  


### PR DESCRIPTION
Hi! 

Thanks for maintaining this site. I'm a longtime reader and first-time contributor :) I was checking the dates for these and I thought I'd contribute them: 

- RailsConf info: http://railsconf.com/
- RubyConf info is on their twitter: https://twitter.com/rubyconf

How'd I do? Anything I should switch up?