### PR TITLE
Close CFP for parisrb

### DIFF
--- a/_data/current.yml
+++ b/_data/current.yml
@@ -104,7 +104,6 @@
   dates: "June 28-29, 2018"
   url: http://2018.rubyparis.org/
   twitter: parisrb
-  cfp_phrase: CFP Open
 
 - name: Brighton Ruby Conference
   location: Brighton, UK


### PR DESCRIPTION
This PR closes the CFP for [paris.rb conf 2018](https://2018.rubyparis.org/)