### PR TITLE
Update Issues URL on 404 page to point to current repo

### DIFF
--- a/404.html
+++ b/404.html
@@ -3,5 +3,5 @@ layout: default
 ---
 <article id="error">
   <h1>Welp, that sucks</h1>
-  <p>There was a problem finding the page you requested - sorry about that. Please feel free to <a href="https://github.com/ruby-conferences/ruby-conferences-site/issues">open an issue</a> about this problem, but you'll probably want to head to the <a href="/">home page</a>.</p>
+  <p>There was a problem finding the page you requested - sorry about that. Please feel free to <a href="https://github.com/ruby-conferences/ruby-conferences.github.io/issues">open an issue</a> about this problem, but you'll probably want to head to the <a href="/">home page</a>.</p>
 </article>


### PR DESCRIPTION
- Still pointing to old repo, ruby-conferences/ruby-conferences-site