### PR TITLE
Add GORUCO 2018

### DIFF
--- a/_data/current.yml
+++ b/_data/current.yml
@@ -69,6 +69,14 @@
   cfp_phrase: CFP closes
   cfp_date: "Apr 1, 2018"
 
+- name: GORUCO 2018
+  location: New York, NY
+  dates: "June 16, 2018"
+  url: http://goruco.com
+  twitter: goruco
+  cfp_phrase: CFP closes
+  cfp_date: "April 15, 2018"
+
 - name: Ruby Conf Kenya 2018
   location: Nairobi, Kenya
   dates: "June 22, 2018"


### PR DESCRIPTION
This adds the upcoming [GORUCO](http://goruco.com) conference in New York.