### PR TITLE
Move RubyKaigi 2018 to PAST and add RubyKaigi 2019 to UPCOMING.

### DIFF
--- a/_data/past.yml
+++ b/_data/past.yml
@@ -1142,3 +1142,15 @@
   dates: "May 25-26, 2018"
   url: http://balkanruby.com/
   twitter: balkanruby
+
+- name: RubyKaigi 2018
+  location: Sendai, Japan
+  dates: "May 31-June 2, 2018"
+  url: http://rubykaigi.org/2018
+  twitter: rubykaigi
+
+- name: RubyC
+  location: Kyiv, Ukraine
+  dates: "June 2-3, 2018"
+  url: http://rubyc.eu/
+  twitter: rubyc_eu

--- a/_data/upcoming.yml
+++ b/_data/upcoming.yml
@@ -1,19 +1,3 @@
-- name: RubyKaigi
-  location: Sendai, Japan
-  dates: "May 31st-June 2nd, 2018"
-  url: http://rubykaigi.org/2018
-  twitter: rubykaigi
-  cfp_phrase: CFP closes
-  cfp_date: "Feb 28, 2018"
-
-- name: RubyC
-  location: Kyiv, Ukraine
-  dates: "June 2-3, 2018"
-  url: http://rubyc.eu/
-  twitter: rubyc_eu
-  cfp_phrase: CFP closes
-  cfp_date: "Apr 1, 2018"
-
 - name: Saint P Rubyconf
   location: Saint Petersburg, Russia
   dates: "June 10, 2018"
@@ -100,6 +84,12 @@
   url: http://rubyconfindia.org/
   twitter: rubyconfindia
   reg_phrase: "Registration Open"
+
+- name: RubyKaigi 2019
+  location: Fukuoka, Japan
+  dates: "April 18-20, 2019"
+  url: https://rubykaigi.org/2019
+  twitter: rubykaigi
 
 - name: RailsConf
   location: Minneapolis, MN


### PR DESCRIPTION
RubyKaigi 2018 is over.
RubyKaigi 2019 will be held next year.