### PR TITLE
Fix mixed content warning

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -3,4 +3,4 @@ The design of the site is copyrighted by Cameron Daigle.
 All other original work uses the Creative Commons
 [Attribution-NonCommercial-ShareAlike 4.0 International License][l].
 
-[l]: http://creativecommons.org/licenses/by-nc-sa/4.0/deed.en_US.
+[l]: https://creativecommons.org/licenses/by-nc-sa/4.0/deed.en_US

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 collaboratively with the Ruby community. Updates are sometimes posted to
 [@rubyconferences][t].
 
-[r]: http://rubyconferences.org/
+[r]: https://rubyconferences.org/
 [t]: https://twitter.com/rubyconferences
 
 ## Eligible Conferences
@@ -67,4 +67,4 @@ The design of the site is copyrighted by Cameron Daigle.
 All other original work uses the Creative Commons
 [Attribution-NonCommercial-ShareAlike 4.0 International License][l].
 
-[l]: http://creativecommons.org/licenses/by-nc-sa/4.0/deed.en_US.
+[l]: https://creativecommons.org/licenses/by-nc-sa/4.0/deed.en_US

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -6,8 +6,8 @@
     <meta content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0" name="viewport">
     <meta content="A curated calendar of Ruby conferences worldwide, including speaking opportunities and registration info." name="description">
     <title>Ruby Conferences</title>
-    <link href="http://fonts.googleapis.com/css?family=Squada+One" rel="stylesheet" type="text/css">
-    <link href="http://fonts.googleapis.com/css?family=Exo+2:300,400" rel="stylesheet" type="text/css">
+    <link href="//fonts.googleapis.com/css?family=Squada+One" rel="stylesheet" type="text/css">
+    <link href="//fonts.googleapis.com/css?family=Exo+2:300,400" rel="stylesheet" type="text/css">
     <link href="/css/style.css" rel="stylesheet" type="text/css">
     <link href="/images/favicon.png" rel="icon" type="image/png">
     <script src="/js/jquery.js" type="text/javascript"></script>
@@ -28,7 +28,7 @@
       {{ content }}
       <footer>
         <p>created &amp; maintained by <a href="http://jonallured.com">Jon Allured</a></p>
-        <p>design &amp; markup by <a href="http://camerondaigle.com">Cameron Daigle</a></p>
+        <p>design &amp; markup by <a href="https://www.camerondaigle.com/">Cameron Daigle</a></p>
         <ul>
           <li><a href="https://twitter.com/rubyconferences">@rubyconferences</a></li>
           <li><a href="https://github.com/ruby-conferences/ruby-conferences.github.io">source</a></li>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,11 +1,11 @@
 ---
 layout: default
 ---
-<article class="post" itemscope itemtype="http://schema.org/BlogPosting">
+<article class="post" itemscope itemtype="https://schema.org/BlogPosting">
 
   <header class="post-header">
     <h1 class="post-title" itemprop="name headline">{{ page.title }}</h1>
-    <p class="post-meta"><time datetime="{{ page.date | date_to_xmlschema }}" itemprop="datePublished">{{ page.date | date: "%b %-d, %Y" }}</time>{% if page.author %} • <span itemprop="author" itemscope itemtype="http://schema.org/Person"><span itemprop="name">{{ page.author }}</span></span>{% endif %}</p>
+    <p class="post-meta"><time datetime="{{ page.date | date_to_xmlschema }}" itemprop="datePublished">{{ page.date | date: "%b %-d, %Y" }}</time>{% if page.author %} • <span itemprop="author" itemscope itemtype="https://schema.org/Person"><span itemprop="name">{{ page.author }}</span></span>{% endif %}</p>
   </header>
 
   <div class="post-content" itemprop="articleBody">


### PR DESCRIPTION
Since the site is now accessible via HTTPS protocol, we should use protocol independent URI to load Google Fonts CSS to avoid mixed content warning.

This commit also update various static links to use HTTPS version if they are available.