### PR TITLE
Add RubyC 2019 (Ukraine/Kyiv)

### DIFF
--- a/_data/upcoming.yml
+++ b/_data/upcoming.yml
@@ -95,3 +95,9 @@
   dates: "August 1-2, 2019"
   url: https://southeastruby.com/
   twitter: southeastruby
+
+- name: RubyC
+  location: Kyiv, Ukraine
+  dates: "September 14-15, 2019"
+  url: https://rubyc.eu/
+  twitter: rubyc_eu


### PR DESCRIPTION
Hi, can you please add RubyC 2019 to conferences list, thanks