### PR TITLE
Update information for RubyConf Thailand

### DIFF
--- a/_data/upcoming.yml
+++ b/_data/upcoming.yml
@@ -77,10 +77,11 @@
   url: https://southeastruby.com/
   twitter: southeastruby
 
-- name: Bangkok.rb
+- name: RubyConf TH
   location: Bangkok, Thailand
   dates: "September 6-7, 2019"
-  url: https://www.meetup.com/bangkok-rb/
+  url: https://rubyconfth.com/
+  twitter: rubyconfth
 
 - name: RubyC
   location: Kyiv, Ukraine


### PR DESCRIPTION
Now we have a live website for the conference and a Twitter account as well ✨

In addition, we initially submitted the conference with the wrong name so this PR fixes that.