### PR TITLE
Add CFP closing date for RubyConf Thailand

### DIFF
--- a/_data/upcoming.yml
+++ b/_data/upcoming.yml
@@ -122,6 +122,8 @@
   dates: "September 6-7, 2019"
   url: https://rubyconfth.com/
   twitter: rubyconfth
+  cfp_phrase: "CFP closes"
+  cfp_date: "June 9, 2019"
 
 - name: RubyC
   location: Kyiv, Ukraine


### PR DESCRIPTION
We recently opened the CFP for RubyConf Thailand: https://www.papercall.io/rubyconfth.