### PR TITLE
Add RubyConf Colombia 2019

### DIFF
--- a/_data/upcoming.yml
+++ b/_data/upcoming.yml
@@ -135,6 +135,12 @@
   cfp_phrase: "CFP closes"
   cfp_date: "March 31, 2019"
 
+- name: RubyConf Colombia
+  location: Medellín, Colombia
+  dates: "September 20-21, 2019"
+  url: https://rubyconf.co
+  twitter: rubyconfco
+
 - name: RubyConf
   location: Nashville, TN
   dates: "November 18-20, 2019"


### PR DESCRIPTION
We just [announced the date](https://twitter.com/RubyConfCo/status/1108508750485151744), the new website should be up in a few weeks.