### PR TITLE
We have a date for Balkan Ruby 2020! 🎉

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1856,3 +1856,12 @@
   end_date: 2020-05-07
   url: https://railsconf.com/
   twitter: railsconf
+
+- name: Balkan Ruby
+  location: Sofia, Bulgaria
+  start_date: 2020-05-15
+  end_date: 2020-05-16
+  url: https://balkanruby.com
+  twitter: balkanruby
+  cfp_phrase: CFP closes
+  cfp_date: 2020-02-01


### PR DESCRIPTION
Hello,

Balkan Ruby is back yet again for its 2020 edition on 15th and 16th of May in Sofia, Bulgaria! 🙌 Our CFP is open until the 1st of February, 2020 and folks can apply at https://cfp.neuvents.com/events/balkan-ruby-2020.