### PR TITLE
Announce dates for RubyConf TH 2020

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1895,6 +1895,13 @@
   url: https://brightonruby.com
   twitter: brightonruby
 
+- name: RubyConf TH
+  location: Bangkok, Thailand
+  start_date: 2020-10-16
+  end_date: 2020-10-17
+  url: https://rubyconfth.com/
+  twitter: rubyconfth
+
 - name: RubyConf
   location: Houston, TX
   start_date: 2020-11-17


### PR DESCRIPTION
RubyConf TH { 💎 } is back for the second year.

New dates are already announced on [the website](https://rubyconfth.com/).