### PR TITLE
Rails Camp West added

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1919,6 +1919,13 @@
   url: https://brightonruby.com
   twitter: brightonruby
 
+- name: Rails Camp West
+  location: Diablo Lake, WA
+  start_date: 2020-09-01
+  end_date: 2020-09-04
+  url: https://west.railscamp.us/2020
+  twitter: railscamp_usa
+
 - name: RubyConf TH
   location: Bangkok, Thailand
   start_date: 2020-10-16


### PR DESCRIPTION
Unconference camp series for the software community to meet & learn from each other while getting out of the city to unplug around a campfire. Sept. 1-4, 2020.