### PR TITLE
Rails Camp 2020 added

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1947,6 +1947,13 @@
   twitter: euruko
   cfp_phrase: "CFP open"
 
+- name: Rails Camp West
+  location: Diablo Lake, WA
+  start_date: 2020-09-01
+  end_date: 2020-09-04
+  url: https://west.railscamp.us/2020
+  twitter: railscamp_usa
+
 - name: RubyC
   location: Kyiv, Ukraine
   start_date: 2020-09-12


### PR DESCRIPTION
Unconference camp series for the software community to meet & learn from each other while getting out of the city to unplug around a campfire. Sept. 1-4, 2020.