### PR TITLE
Add Ruby Unconf Hamburg 2020 on 6th & 7th of June

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1938,6 +1938,14 @@
   url: https://spbrubyconf.ru/
   twitter: saintpruby
   video_link: https://www.youtube.com/playlist?list=PLM_LdV8tMIazzAKhtGxJvYCPCgP8HiB5k
+  
+- name: Ruby Unconf Hamburg
+  location: Hamburg, Germany
+  start_date: 2020-06-06
+  end_date: 2020-06-07
+  url: https://2020.rubyunconf.eu/
+  twitter: rubyunconfeu
+  video_link: https://www.youtube.com/channel/UCpdY3gEqGW10EVrUbd1itug
 
 - name: Brighton Ruby Conf
   location: Brighton, UK


### PR DESCRIPTION
Thanks a lot for the site and repo!

Here's the conference URL
https://2020.rubyunconf.eu/

In the README it's stated that `video_url` is for past conferences. I added a link to their channel even though the yaml entry in total is for an  upcoming conference, hope that it won't put it into past events because of this.