### PR TITLE
Add CFP note for RubyConfBY

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1905,6 +1905,8 @@
   end_date: 2020-04-18
   url: https://rubyconference.by/
   twitter: RubyConfBY
+  cfp_phrase: CFP closes
+  cfp_date: 2020-03-05
 
 - name: RubyConfIndia
   location: Goa, India


### PR DESCRIPTION
There's a [CFP Page](https://www.papercall.io/rubyconfby20) for the conference. Figured it would be nice to have it on the website