### PR TITLE
Move video_link to the right place 🚀

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1846,6 +1846,7 @@
   reg_date: 2020-01-28
   cfp_phrase: "CFP open"
   cfp_date: 2019-12-31
+  video_link: https://www.youtube.com/playlist?&list=PLE7tQUdRKcyYC2lZzwTvEeJXghm4Ym4ZX
 
 - name: Rubyfuza
   location: Cape Town, South Africa
@@ -1855,7 +1856,6 @@
   twitter: rubyfuza
   cfp_phrase: "CFP closes"
   cfp_date: 2019-12-01
-  video_link: https://www.youtube.com/watch?v=EypRSLfKvak&list=PLE7tQUdRKcyYC2lZzwTvEeJXghm4Ym4ZX
 
 - name: ParisRB Conf
   location: Paris, France


### PR DESCRIPTION
## The problem
**Rubyfuza** conference has wrong video link. This video link is a playlist for the **Birmingham on Rails 2020** conference.

## The solution
* move `video_link` to the right place
* format `video_link` properly

## Before

![Screen Shot 2020-03-13 at 00 12 04](https://user-images.githubusercontent.com/2473081/76567257-6d175c00-64bf-11ea-8e9f-068dcbdaba9d.png)

## After

![Screen Shot 2020-03-13 at 00 12 32](https://user-images.githubusercontent.com/2473081/76567288-7a344b00-64bf-11ea-9110-0b392b6454cf.png)
