### PR TITLE
Fix RubyWorld Conference 2018 Event Videos link 🔄

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1527,7 +1527,7 @@
   end_date: 2018-11-02
   url: http://2018.rubyworld-conf.org/
   twitter: rubyworldconf
-  video_link: http://2018.rubyworld-conf.org/en/program/
+  video_link: https://2018.rubyworld-conf.org/program/
 
 - name: Keep Ruby Weird
   location: Austin, TX


### PR DESCRIPTION
## Before

http://2018.rubyworld-conf.org/en/program/
![Screen Shot 2020-03-30 at 13 41 34](https://user-images.githubusercontent.com/2473081/77904754-be7c6500-728d-11ea-886c-1c12c1deb6d4.png)

## After

https://2018.rubyworld-conf.org/program/
![Screen Shot 2020-03-30 at 13 46 37](https://user-images.githubusercontent.com/2473081/77904788-ccca8100-728d-11ea-91ca-c26caa08bbec.png)
