### PR TITLE
Remove Unconf Hamburg

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1923,13 +1923,6 @@
   url: https://spbrubyconf.ru/
   twitter: saintpruby
 
-- name: Ruby Unconf Hamburg
-  location: Hamburg, Germany
-  start_date: 2020-06-06
-  end_date: 2020-06-07
-  url: https://2020.rubyunconf.eu/
-  twitter: rubyunconfeu
-
 - name: Brighton Ruby Conf
   location: Brighton, UK
   start_date: 2020-07-03


### PR DESCRIPTION
[Ruby Unconf Hamburg](https://2020.rubyunconf.eu/) was cancelled.