### PR TITLE
Removing RubyC due to cancellation

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1952,15 +1952,6 @@
   url: https://rubykaigi.org/2020
   twitter: rubykaigi
 
-- name: RubyC
-  location: Kyiv, Ukraine
-  start_date: 2020-09-12
-  end_date: 2020-09-13
-  url: http://rubyc.eu/
-  twitter: rubyc_eu
-  cfp_phrase: CFP closes
-  cfp_date: 2020-05-15
-
 - name: RubyDay
   location: Verona, Italy
   start_date: 2020-09-16


### PR DESCRIPTION
RubyC 2020 was canceled due to COVID - https://rubyc.eu/posts/117