### PR TITLE
Fix RubyConf India 2014 event videos link 🔧

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -72,7 +72,7 @@
   end_date: 2014-03-23
   url: https://2014.rubyconfindia.org/
   twitter: rubyconfindia
-  video_link: https://www.youtube.com/channel/UCRNZy_ouJ1ai_uYwDBR2J5Q
+  video_link: https://www.youtube.com/playlist?list=PLNyYRB_d4fk2Hz8_HuHIAPv5dJGrnxh14
 
 - name: RubyConf Philippines
   location: Manila, Philippines


### PR DESCRIPTION
## Before

![Screenshot 2020-05-27 at 21 46 38](https://user-images.githubusercontent.com/2473081/83060675-86fb2080-a064-11ea-934e-19e0d9b1ff0e.png)
Channel with various videos from different conferences

## After

![Screenshot 2020-05-27 at 21 46 51](https://user-images.githubusercontent.com/2473081/83060759-a2fec200-a064-11ea-8846-4d82966ae096.png)
RubyConf India 2014 playlist
