### PR TITLE
Postpone RubyConfBY 2020 ⏳

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1902,13 +1902,6 @@
   cfp_phrase: CFP closes
   cfp_date: 2020-01-19
 
-- name: RubyConfBY
-  location: Minsk, Belarus
-  start_date: 2020-04-18
-  end_date: 2020-04-18
-  url: https://rubyconference.by/
-  twitter: RubyConfBY
-
 - name: RubyConfIndia
   location: Goa, India
   start_date: 2020-04-25
@@ -1937,6 +1930,13 @@
   end_date: 2020-07-03
   url: https://brightonruby.com
   twitter: brightonruby
+
+- name: RubyConfBY
+  location: Minsk, Belarus
+  start_date: 2020-07-18
+  end_date: 2020-07-19
+  url: https://rubyconference.by/
+  twitter: RubyConfBY
 
 - name: Rails Camp West
   location: Diablo Lake, WA


### PR DESCRIPTION
RubyConfBY 2020 is postponed due to COVID-19.
https://twitter.com/RubyConfBY/status/1238374237208903680
https://rubyconference.by/
https://www.facebook.com/events/603187860428073/

![image](https://user-images.githubusercontent.com/2473081/84813903-59791580-b019-11ea-8e95-b6173c9faae0.png)