### PR TITLE
Update RubyKaigi 2020 info ℹ️

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1954,12 +1954,13 @@
   url: https://west.railscamp.us/2020
   twitter: railscamp_usa
 
-- name: RubyKaigi
-  location: Nagano, Japan
-  start_date: 2020-09-03
+- name: RubyKaigi Takeout
+  location: Online
+  start_date: 2020-09-04
   end_date: 2020-09-05
-  url: https://rubykaigi.org/2020
+  url: https://rubykaigi.org/2020-takeout
   twitter: rubykaigi
+  video_link: https://www.youtube.com/playlist?list=PLbFmgWm555yZeLpdOLhYwORIF9UjBAFHw
 
 - name: RubyDay
   location: Verona, Italy


### PR DESCRIPTION
Instead of having RubyKaigi 2020 offline,
![RubyKaigi-2020](https://user-images.githubusercontent.com/2473081/97291056-7391f280-185a-11eb-8137-6249899c3a52.png)
https://rubykaigi.org/2020

there was RubyKaigi Takeout 2020 online
![RubyKaigi-Takeout-2020](https://user-images.githubusercontent.com/2473081/97291195-a1773700-185a-11eb-98ff-ed3c52a42905.png)
https://rubykaigi.org/2020-takeout