### PR TITLE
RailsCamp 2020 turned 2021 has been postponed till 2022 🙀

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1942,13 +1942,6 @@
   cfp_phrase: CFP closes
   cfp_date: 2020-08-17
 
-- name: Rails Camp West
-  location: Diablo Lake, WA
-  start_date: 2020-09-01
-  end_date: 2020-09-04
-  url: https://west.railscamp.us/2020
-  twitter: railscamp_usa
-
 - name: RubyKaigi Takeout
   location: Online
   start_date: 2020-09-04
@@ -2014,3 +2007,10 @@
   twitter: euruko
   cfp_phrase: CFP closes
   cfp_date: 2021-04-18
+
+- name: Rails Camp West
+  location: Diablo Lake, WA
+  start_date: 2022-08-30
+  end_date: 2022-09-02
+  url: https://west.railscamp.us/2022
+  twitter: railscamp_usa


### PR DESCRIPTION
![Screenshot 2021-04-12 at 14 39 43](https://user-images.githubusercontent.com/2473081/114389007-2520a800-9b9d-11eb-884d-d7693850ce7f.png)

https://twitter.com/railscamp_USA/status/1365006856993710081

![COVID-19-Updates-Rails-Camp-West](https://user-images.githubusercontent.com/2473081/114388993-19cd7c80-9b9d-11eb-9cea-52a5c71b8eb9.png)
https://west.railscamp.us/covid-19-updates