### PR TITLE
Add RubyConf TH 2022

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -2133,3 +2133,10 @@
   end_date: 2022-12-01
   url: https://rubyconf.org/
   twitter: rubyconf
+
+- name: RubyConf TH 2022
+  location: Bangkok, Thailand
+  start_date: 2022-12-10
+  end_date: 2022-12-11
+  url: https://rubyconfth.com/
+  twitter: rubyconfth


### PR DESCRIPTION
RubyConf TH { 💎 } is back in 2022 after a two-year break

New dates are already announced on [the website](https://rubyconfth.com/).