### PR TITLE
Fix RubyConf Mini

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -2150,7 +2150,7 @@
   cfp_phrase: CFP closes
   cfp_date: 2022-09-30
 
-- RubyConf Mini, 2022
+- name: RubyConf Mini, 2022
   location: Providence, RI, USA
   start_date: 2022-11-15
   end_date: 2022-11-17


### PR DESCRIPTION
The [deploy broke](https://github.com/ruby-conferences/ruby-conferences.github.io/actions/runs/3113533401/jobs/5048283590) due to the missing `name: `. This commit adds that to fix the deploy, and add RubyConf Mini to the site