### PR TITLE
Update order of RubyConf Mini

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -2133,6 +2133,13 @@
   end_date: 2022-09-10
   url: https://rubykaigi.org/2022
   twitter: rubykaigi
+  
+- name: RubyConf Mini, 2022
+  location: Providence, RI, USA
+  start_date: 2022-11-15
+  end_date: 2022-11-17
+  url: https://www.rubyconfmini.com
+  twitter: rubyconfmini
 
 - name: RubyConf, 2022
   location: Houston, Texas
@@ -2149,13 +2156,6 @@
   twitter: rubyconfth
   cfp_phrase: CFP closes
   cfp_date: 2022-09-30
-
-- name: RubyConf Mini, 2022
-  location: Providence, RI, USA
-  start_date: 2022-11-15
-  end_date: 2022-11-17
-  url: https://www.rubyconfmini.com
-  twitter: rubyconfmini
 
 - name: RubyConf Australia
   location: Melbourne, Australia


### PR DESCRIPTION
RubyConf Mini was incorrectly ordered, showing in the list after RubyConf 2022, and RubyConf TH 2022; both of which it occurs before.