### PR TITLE
move CFP close date to cfp_phrase to avoid confusion

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -2246,5 +2246,4 @@
   url: https://helvetic-ruby.ch
   twitter: helvetic_ruby
   mastodon: https://ruby.social/@helvetic_ruby
-  cfp_phrase: CFP open
-  cfp_date: 2023-03-31
+  cfp_phrase: CFP open now, closes on 2023-03-31


### PR DESCRIPTION
Hi again 👋 

Apologies for the spam. 🙃 

I just realized that using the `cfp_date` the phrasing ended up being confusing/wrong

![Screenshot 2023-02-15 at 15 45 14](https://user-images.githubusercontent.com/1409672/219061186-adbe0340-5db3-4735-bd6a-8c6496619768.png)

(I didn't test it locally, shame on me!)

May be there's better way to use `cfp_date` in combination with `cfp_phrase`, but for now I just moved the information to `cfp_phrase`.

Let me know if/how I can improve that?