### PR TITLE
Sort conferences automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ but it's probably not a Ruby conference.
 
 The list of events is driven by the conferences file in the `_data` directory - if you have an update for those things, just change the YAML and send a PR.
 
-The file to be changed is `_data/conferences.yml`. **NOTE: It is
-order-dependent, meaning, put your conference in the YAML file in the order in
-which it should appear on the page, which is chronological.**
+The file to be changed is `_data/conferences.yml`. It is NOT order-dependent.
+Put your conference in the YAML file at the end.
+The page will sort the conferences by `start_date`.
 
 Here is a list of the keys that can be used:
 

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -2352,6 +2352,15 @@
   url: https://helvetic-ruby.ch
   twitter: helvetic_ruby
   mastodon: https://ruby.social/@helvetic_ruby
+
+- name: RubyConf 2023
+  location: San Diego, CA
+  start_date: 2023-11-06
+  end_date: 2023-11-08
+  url: https://rubyconf.org
+  twitter: rubyconf
+  mastodon: https://ruby.social/@rubyconf
+
 - name: RubyConf Taiwan 2023
   location: Taipei, Taiwan
   start_date: 2023-12-15

--- a/index.html
+++ b/index.html
@@ -4,7 +4,8 @@ layout: default
 <article id="home">
   <dl>
     {% assign now = site.time | date: '%s' | plus: 0 %}
-    {% for event in site.data.conferences %}
+    {% assign conferences = site.data.conferences | sort: "start_date" %}
+    {% for event in conferences %}
       {% assign start_date = event.start_date | date: '%s' | plus: 0 %}
       {% if start_date > now %}
         {% include event.html %}


### PR DESCRIPTION
Reason for Change
=================
* Previously, the conference data source had to be in chronological order for the page to render them in order.

Changes
=======
* Sort the data by the `start_date` attribute
* Update the `README.md` to reflect the change
* Put the data out of order to test the result - it works!

Minor
-----
* Relevant docs: https://shopify.github.io/liquid/filters/sort/

![image of correctly sorted list](https://user-images.githubusercontent.com/913757/231270478-7fa32e66-394d-4420-8ff8-db8dae533938.png)
