### PR TITLE
Add RailsConf 2024

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -2282,7 +2282,7 @@
   cfp_phrase: CFP closes
   cfp_date: 2023-06-04
   mastodon: https://ruby.social/@rubyconfth
-  
+
 - name: Kaigi on Rails 2023
   location: Tokyo, Japan
   start_date: 2023-10-27
@@ -2306,3 +2306,11 @@
   url: https://helvetic-ruby.ch
   twitter: helvetic_ruby
   mastodon: https://ruby.social/@helvetic_ruby
+
+- name: RailsConf 2024
+  location: Detroit, MI
+  start_date: 2024-05-07
+  end_date: 2024-05-09
+  url: https://www.railsconf.com
+  twitter: railsconf
+  mastodon: https://ruby.social/@railsconf


### PR DESCRIPTION
> Thank you for joining us for RailsConf 2023! We had a great time and hope you’ll join us again next year in Detroit, MI (May 7 - 9, 2024).