### PR TITLE
Add `calendar.ics` template

### DIFF
--- a/calendar.ics
+++ b/calendar.ics
@@ -1,0 +1,18 @@
+---
+layout: null
+---
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:https://www.rubyconferences.org/
+METHOD:PUBLISH{% for event in site.data.conferences %}
+BEGIN:VEVENT
+UID:{{ event.start_date | date: "%Y%m%d" | append: event.name }}@rubyconferences.org
+SUMMARY:{{ event.name }}
+LOCATION:{{ event.location | replace: ",", "\\," }}
+DESCRIPTION:{% if event.twitter %}Twitter:\nhttps://twitter.com/{{ event.twitter }}\n{% endif %}{% if event.mastodon %}\nMastodon:\n{{ event.mastodon }}{% endif %}{% if event.video_link %}\nVideo Link:\n{{ event.video_link }}\n{% endif %}
+CLASS:PUBLIC
+URL:{{ event.url }}
+DTSTART;VALUE=DATE:{{ event.start_date | date: "%Y%m%d" }}
+DTEND;VALUE=DATE:{{ event.end_date | date: "%Y%m%d" | plus: 1 }}
+END:VEVENT{% endfor %}
+END:VCALENDAR


### PR DESCRIPTION
This pull request adds a `calendar.ics` file which contains all the events in the iCal format. This is ideal because this lets you add https://www.rubyconferences.org/calendar.ics as a calendar subscription to your calendar of choice without having to add the events yourself.

![Screenshot 2023-05-05 at 20 47 02](https://user-images.githubusercontent.com/6411752/236543181-dc47cdfe-dc3b-476b-a3b7-09fddbc8226c.png)
