### PR TITLE
Add Rocky Mountain Ruby 2023

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -2281,6 +2281,14 @@
   twitter: rails
   cfp_phrase: CFP open
 
+- name: Rocky Mountain Ruby
+  location: Boulder, Colorado
+  start_date: 2023-10-05
+  end_date: 2023-10-06
+  url: https://rockymtnruby.dev/
+  mastodon: https://ruby.social/@rockymntruby
+  cfp_phrase: CFP open
+
 - name: RubyConf TH 2023
   location: Bangkok, Thailand
   start_date: 2023-10-06


### PR DESCRIPTION
Rocky Mountain Ruby is returning in Boulder Colorado October 5th and 6th, 2023. Thanks!