### PR TITLE
Add link to .ics feed to homepage

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -32,6 +32,7 @@
         <ul>
           <li><a href="https://twitter.com/rubyconferences">@rubyconferences</a></li>
           <li><a href="https://github.com/ruby-conferences/ruby-conferences.github.io">source</a></li>
+          <li><a href="http://www.rubyconferences.org/calendar.ics">ics calendar feed</a></li>
         </ul>
       </footer>
       <script type="text/javascript">


### PR DESCRIPTION
Reason for Change
=================
* The iCal feed is cool! More people should know about it and use it
* The change was implemented in [this PR](https://github.com/ruby-conferences/ruby-conferences.github.io/pull/492)

Changes
=======
* Add link to .ics feed in the layout file