### PR TITLE
Add canceled events back

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1947,6 +1947,14 @@
   twitter: balkanruby
   status: Canceled
 
+- name: Ruby Unconf Hamburg 2020
+  location: Hamburg, Germany
+  start_date: 2020-06-06
+  end_date: 2020-06-07
+  url: https://2020.rubyunconf.eu/
+  twitter: rubyunconfeu
+  status: Canceled
+
 - name: Brighton Ruby Conf
   location: Online
   start_date: 2020-07-03

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1955,6 +1955,14 @@
   twitter: rubyunconfeu
   status: Canceled
 
+- name: Saint P Rubyconf 2020
+  location: Saint Petersburg, Russia
+  start_date: 2020-06-06
+  end_date: 2020-06-07
+  url: https://spbrubyconf.ru/
+  twitter: saintpruby
+  status: Canceled
+
 - name: Brighton Ruby Conf
   location: Online
   start_date: 2020-07-03

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1901,6 +1901,14 @@
   twitter: wrocloverb
   status: Canceled
 
+- name: Ruby Retreat NZ 2020
+  location: Mt Cheeseman, near Christchurch, New Zealand
+  url: https://retreat.ruby.nz
+  start_date: 2020-03-27
+  end_date: 2020-03-30
+  twitter: RubyNewZealand
+  status: Canceled
+
 - name: Ruby by the Bay (Ruby for Good)
   location: Sausalito, CA
   start_date: 2020-04-03

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1893,6 +1893,14 @@
   twitter: rubyconf_au
   video_link: https://www.youtube.com/playlist?list=PL9_jjLrTYxc1G0L8h-rMtO3fBSi4PJK26
 
+- name: wroclove.rb 2020
+  location: Wrocław, Poland
+  start_date: 2020-03-20
+  end_date: 2020-03-22
+  url: https://2020.wrocloverb.com
+  twitter: wrocloverb
+  status: Canceled
+
 - name: Ruby by the Bay (Ruby for Good)
   location: Sausalito, CA
   start_date: 2020-04-03
@@ -1924,15 +1932,31 @@
   twitter: railsconf
   video_link: https://www.youtube.com/playlist?list=PLE7tQUdRKcyZ-TzxlxdLvh6tDUfZHqm76
 
+- name: Balkan Ruby
+  location: Sofia, Bulgaria
+  start_date: 2020-05-15
+  end_date: 2020-05-16
+  url: https://balkanruby.com
+  twitter: balkanruby
+  status: Canceled
+
 - name: Brighton Ruby Conf
-  location: Brighton, UK
+  location: Online
   start_date: 2020-07-03
   end_date: 2020-07-03
-  url: https://brightonruby.com
+  url: https://brightonruby.com/2020
   twitter: brightonruby
 
+- name: RubyNess
+  location: Inverness, Scotland
+  start_date: 2020-07-16
+  end_date: 2020-07-17
+  url: https://rubyness.org/
+  twitter: rubynessconf
+  status: Canceled
+
 - name: RubyConfBY
-  location: Minsk, Belarus
+  location: Online
   start_date: 2020-07-18
   end_date: 2020-07-19
   url: https://rubyconference.by/
@@ -1958,12 +1982,20 @@
   video_link: https://www.youtube.com/playlist?list=PLbFmgWm555yZeLpdOLhYwORIF9UjBAFHw
 
 - name: RubyDay
-  location: Verona, Italy
+  location: Online
   start_date: 2020-09-16
   end_date: 2020-09-16
   url: https://2020.rubyday.it
   twitter: rubydayit
   video_link: https://www.youtube.com/playlist?list=PLWK9j6ps_unl0S5Xmi6FVfDLFUkntQTfK
+
+- name: RubyConf TH
+  location: Bangkok, Thailand
+  start_date: 2020-10-16
+  end_date: 2020-10-17
+  url: https://rubyconfth.com/
+  twitter: rubyconfth
+  status: Canceled
 
 - name: ROSS conf
   location: Online

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1909,13 +1909,11 @@
   twitter: rubyforgood
 
 - name: Ruby Wine 2.0
-  location: Chisinau, Moldova
+  location: Online
   start_date: 2020-04-04
   end_date: 2020-04-04
   url: https://www.rubywine.org
   twitter: rubymeditation
-  cfp_phrase: CFP closes
-  cfp_date: 2020-01-19
 
 - name: RubyConfIndia
   location: Goa, India
@@ -1923,6 +1921,7 @@
   end_date: 2020-04-26
   url: https://rubyconfindia.org
   twitter: rubyconfindia
+  status: Canceled
 
 - name: RailsConf 2020.2 COUCH EDITION
   location: Your Couch

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1996,6 +1996,15 @@
   twitter: rubykaigi
   video_link: https://www.youtube.com/playlist?list=PLbFmgWm555yZeLpdOLhYwORIF9UjBAFHw
 
+- name: RubyC 2020
+  location: Kyiv, Ukraine
+  start_date: 2020-09-12
+  end_date: 2020-09-13
+  url: http://rubyc.eu/
+  twitter: rubyc_eu
+  cfp_phrase: CFP closes
+  status: Canceled
+
 - name: RubyDay
   location: Online
   start_date: 2020-09-16


### PR DESCRIPTION
Previously we deleted canceled conferences out of this list. Now that we have an optional `status` field (introduced in pull request #369) we can add those events back and have them as part of the historical record.