### PR TITLE
Remove duplicate RubyConf 2023

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -2424,14 +2424,6 @@
   twitter: helvetic_ruby
   mastodon: https://ruby.social/@helvetic_ruby
 
-- name: RubyConf 2023
-  location: San Diego, CA
-  start_date: 2023-11-06
-  end_date: 2023-11-08
-  url: https://rubyconf.org
-  twitter: rubyconf
-  mastodon: https://ruby.social/@rubyconf
-
 - name: RubyConf Taiwan 2023
   location: Taipei, Taiwan
   start_date: 2023-12-15


### PR DESCRIPTION
Somehow we have RubyConf 2023 twice in the list, even with different dates.