### PR TITLE
Data cleanup

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -13,12 +13,12 @@
   twitter: rubyfuza
   video_link: http://www.confreaks.com/events/rubyfuza2014
 
-- name: Los Angeles Ruby Conference
+- name: Los Angeles Ruby Conference 2014
   location: Los Angeles, CA
   start_date: 2014-02-08
   end_date: 2014-02-08
   twitter: larubyconf
-  video_link: http://confreaks.com/events/larubyconf2014
+  video_link: https://www.youtube.com/playlist?list=PLE7tQUdRKcyYidNh3m57hyDjjKGC9-rbj
 
 - name: Ruby Conf Australia
   location: Sydney, Australia
@@ -26,15 +26,15 @@
   end_date: 2014-02-21
   url: https://rubyconf.org.au/2014
   twitter: rubyconf_au
-  video_link: http://vimeo.com/channels/699773
+  video_link: https://vimeo.com/channels/699773
 
-- name: Big Ruby
+- name: Big Ruby 2014
   location: Dallas, TX
   start_date: 2014-02-20
   end_date: 2014-02-21
   url: http://web.archive.org/web/20140228185424/http://www.bigrubyconf.com:80/
   twitter: bigrubyconf
-  video_link: http://confreaks.com/events/bigruby2014
+  video_link: https://www.youtube.com/playlist?list=PLE7tQUdRKcybDQsdHP1e7msGEalUPaV06
 
 - name: RubySauna
   location: Oulu, Finland
@@ -43,18 +43,18 @@
   url: http://web.archive.org/web/20140213081334/http://www.rubysauna.org:80/
   twitter: rubysauna
 
-- name: Ruby on Ales
+- name: Ruby on Ales 2014
   location: Bend, OR
   start_date: 2014-03-06
   end_date: 2014-03-07
   twitter: rbonales
   video_link: http://www.confreaks.com/events/roa2014
 
-- name: wroc_love.rb
+- name: wroc_love.rb 2014
   location: Wrocław, Poland
   start_date: 2014-03-14
   end_date: 2014-03-16
-  url: http://wrocloverb.com/
+  url: https://2014.wrocloverb.com
   twitter: wrocloverb
   video_link: https://www.youtube.com/playlist?list=PLoGBNJiQoqRCYNOfsPoxVWChbT5x5D5WP
 
@@ -66,7 +66,7 @@
   twitter: mwrc
   video_link: http://confreaks.tv/events/mwrc2014
 
-- name: RubyConf India
+- name: RubyConf India 2014
   location: Goa, India
   start_date: 2014-03-22
   end_date: 2014-03-23
@@ -89,13 +89,13 @@
   twitter: ancientcityruby
   video_link: https://www.youtube.com/playlist?list=PLrjohaqTgNJMDh6Jg0vPftT2S34zPEPhJ
 
-- name: RailsConf
+- name: RailsConf 2014
   location: Chicago, IL
   start_date: 2014-04-22
   end_date: 2014-04-25
-  url: http://www.railsconf.com/
+  url: https://www.railsconf.com/
   twitter: railsconf
-  video_link: http://confreaks.tv/events/railsconf2014
+  video_link: https://www.youtube.com/playlist?list=PLE7tQUdRKcyZ5jfnbS_osIoWzK_FrwKz5
 
 - name: Abril Pro Ruby
   location: Porto de Galinhas, Brazil
@@ -159,13 +159,13 @@
   url: http://2014.rulu.eu/
   twitter: rulu
 
-- name: Gotham Ruby Conference
+- name: GORUCO 2014
   location: New York, NY
   start_date: 2014-06-21
   end_date: 2014-06-21
   url: http://goruco.com/
   twitter: goruco
-  video_link: http://confreaks.tv/events/goruco2014
+  video_link: https://www.youtube.com/playlist?list=PLE7tQUdRKcyZj4qdxsQKW4-8KnlpoGfgf
 
 - name: RedDotRubyConf
   location: Singapore
@@ -181,11 +181,12 @@
   end_date: 2014-07-19
   twitter: deccanrubyconf
 
-- name: Brighton Ruby Conf
+- name: Brighton Ruby 2014
   location: Brighton, UK
   start_date: 2014-07-21
   end_date: 2014-07-21
-  url: https://brightonruby.com/2014/
+  url: https://brightonruby.com/2014
+  video_link: https://brightonruby.com/2014
   twitter: brightonruby
 
 - name: Burlington Ruby Conference
@@ -364,13 +365,13 @@
   url: http://2014.rubyworld-conf.org/en/
   twitter: rubyworldconf
 
-- name: RubyConf
+- name: RubyConf 2014
   location: San Diego, CA
   start_date: 2014-11-17
   end_date: 2014-11-19
-  url: http://rubyconf.org/
+  url: https://rubyconf.org/
   twitter: rubyconf
-  video_link: http://www.confreaks.com/events/RubyConf2014
+  video_link: https://www.youtube.com/playlist?list=PLE7tQUdRKcyYajZ5aZlJf1g2u5Boq-jic
 
 - name: Garden City RubyConf
   location: Bangalore, India
@@ -434,11 +435,11 @@
   twitter: BathRuby
   video_link: http://confreaks.tv/events/bathruby2015
 
-- name: wroc_love.rb
+- name: wroc_love.rb 2015
   location: Wrocław, Poland
   start_date: 2015-03-13
   end_date: 2015-03-15
-  url: http://wrocloverb.com/
+  url: https://2015.wrocloverb.com
   twitter: wrocloverb
 
 - name: RubyConfLT
@@ -518,15 +519,15 @@
   url: http://www.rubynation.org/
   twitter: rubynation
 
-- name: Gotham Ruby Conference
+- name: GORUCO 2015
   location: New York, NY
   start_date: 2015-07-20
   end_date: 2015-07-20
   url: http://2015.goruco.com/
   twitter: goruco
-  video_link: http://confreaks.tv/events/goruco2015
+  video_link: https://www.youtube.com/playlist?list=PLE7tQUdRKcyb6MU6H8PratMhV4bWUL8bv
 
-- name: Brighton Ruby
+- name: Brighton Ruby 2015
   location: Brighton, UK
   start_date: 2015-07-20
   end_date: 2015-07-20
@@ -658,11 +659,11 @@
   twitter: rubyconfco
   video_link: https://www.youtube.com/playlist?list=PLq_08z5fuQgFP64HqrRWd3RWUKmPFMdo6
 
-- name: EuRuKo
+- name: EuRuKo 2015
   location: Salzburg, Austria
   start_date: 2015-10-17
   end_date: 2015-10-18
-  url: http://www.euruko2015.org/
+  url: https://2015.euruko.org
   twitter: euruko
 
 - name: Keep Ruby Weird
@@ -689,13 +690,13 @@
   twitter: rubydayit
   video_link: https://www.youtube.com/playlist?list=PL5ImBN21eKvaTC30b0rwaIWe3DRLr062d
 
-- name: RubyConf
+- name: RubyConf 2015
   location: San Antonio, TX
   start_date: 2015-11-15
   end_date: 2015-11-17
   url: http://rubyconf.org/
   twitter: rubyconf
-  video_link: http://confreaks.tv/events/rubyconf2015
+  video_link: https://www.youtube.com/playlist?list=PLE7tQUdRKcyYqT3LHMg4iH270kfyENCpp
 
 - name: RailsIsrael
   location: Tel Aviv, Israel
@@ -742,11 +743,11 @@
   twitter: bathruby
   video_link: http://confreaks.tv/events/bathruby2016
 
-- name: wroc_love.rb
+- name: wroc_love.rb 2016
   location: Wrocław, Poland
   start_date: 2016-03-11
   end_date: 2016-03-13
-  url: http://wrocloverb.com
+  url: https://2016.wrocloverb.com
   twitter: wrocloverb
 
 - name: RubyConfIndia
@@ -805,13 +806,13 @@
   twitter: rubyconfby
   video_link: https://www.youtube.com/playlist?list=PLpVeA1tdgfCC82YnUz8sAsjmNyPWxIr9l
 
-- name: RailsConf
+- name: RailsConf 2016
   location: Kansas City, MO
   start_date: 2016-05-04
   end_date: 2016-05-06
   url: http://www.railsconf.com/2016
   twitter: railsconf
-  video_link: http://confreaks.tv/events/railsconf2016
+  video_link: https://www.youtube.com/playlist?list=PLE7tQUdRKcyZGYLfj6oRQWPxB6ijg1YsC
 
 - name: Rails Pacific
   location: Taipei, Taiwan
@@ -864,13 +865,13 @@
   end_date: 2016-06-26
   twitter: grill_rb
 
-- name: GORUCO (Gotham Ruby Conference)
+- name: GORUCO 2016
   location: New York, NY
   start_date: 2016-06-25
   end_date: 2016-06-25
   url: http://2016.goruco.com/
   twitter: goruco
-  video_link: http://confreaks.tv/events/goruco2016
+  video_link: https://www.youtube.com/playlist?list=PLE7tQUdRKcybaE0Xm_yOK8-a-WAcltv1q
 
 - name: OpenCommerce Conf
   location: Rise, New York City
@@ -879,7 +880,7 @@
   url: http://opencommerceconf.org/
   twitter: opencommerce_
 
-- name: Brighton Ruby Conference
+- name: Brighton Ruby 2016
   location: Brighton, UK
   start_date: 2016-07-08
   end_date: 2016-07-08
@@ -940,11 +941,11 @@
   twitter: rockymtnruby
   video_link: http://confreaks.tv/events/rockymountainruby2016
 
-- name: EuRuKo
+- name: EuRuKo 2016
   location: Sofia, Bulgaria
   start_date: 2016-09-23
   end_date: 2016-09-24
-  url: http://euruko2016.org/
+  url: https://2016.euruko.org
   twitter: euruko
   video_link: https://www.youtube.com/channel/UChGs1td4ViQFqT0jlvkyUJg/videos
 
@@ -1000,7 +1001,7 @@
   twitter: rubyworldconf
   video_link: http://2016.rubyworld-conf.org/en/program/
 
-- name: RubyConf
+- name: RubyConf 2016
   location: Cincinnati, OH
   start_date: 2016-11-10
   end_date: 2016-11-12
@@ -1069,11 +1070,11 @@
   twitter: rubyconfph
   video_link: https://www.youtube.com/playlist?list=PL0mVjsUoElSHKtxq2efDQc6EXTDqabxdV
 
-- name: wroc_love.rb
+- name: wroc_love.rb 2017
   location: Wrocław, Poland
   start_date: 2017-03-17
   end_date: 2017-03-19
-  url: http://www.wrocloverb.com/
+  url: https://2017.wrocloverb.com
   twitter: wrocloverb
 
 - name: RubyConfLT
@@ -1099,13 +1100,13 @@
   twitter: utrubyhack
   video_link: https://confreaks.tv/events/rubyhack2017
 
-- name: RailsConf
+- name: RailsConf 2017
   location: Phoenix, AZ
   start_date: 2017-04-25
   end_date: 2017-04-27
   url: http://www.railsconf.com/2017
   twitter: railsconf
-  video_link: http://confreaks.tv/events/railsconf2017
+  video_link: https://www.youtube.com/playlist?list=PLE7tQUdRKcyarr-2jYCnnlb7wl-aEz4xt
 
 - name: RubyC
   location: Kyiv, Ukraine
@@ -1139,13 +1140,13 @@
   twitter: reddotrubyconf
   video_link: http://confreaks.tv/events/reddotrubyconf2017
 
-- name: GORUCO
+- name: GORUCO 2017
   location: New York, NY
   start_date: 2017-06-24
   end_date: 2017-06-24
   url: http://2017.goruco.com/
   twitter: goruco
-  video_link: https://confreaks.tv/events/goruco2017
+  video_link: https://www.youtube.com/playlist?list=PLE7tQUdRKcybxOnh9S9Hk-RDRXZRkrWwR
 
 - name: GrillRB
   location: Wrocław, PL
@@ -1154,7 +1155,7 @@
   twitter: grill_rb
   video_link: https://www.youtube.com/playlist?list=PLDraF2Fjmu8VuZ8CohiG4EZuwHpUACUIN
 
-- name: Brighton Ruby Conf
+- name: Brighton Ruby 2017
   location: Brighton, UK
   start_date: 2017-07-07
   end_date: 2017-07-07
@@ -1199,11 +1200,11 @@
   twitter: railsclub_ru
   video_link: https://www.youtube.com/playlist?list=PLiWUIs1hSNeMBqHPF7HcO6O2WBjzfiUQw
 
-- name: EuRuKo
+- name: EuRuKo 2017
   location: Budapest, Hungary
   start_date: 2017-09-29
   end_date: 2017-09-30
-  url: http://www.euruko2017.org
+  url: https://2017.euruko.org
   twitter: euruko
   video_link: https://www.youtube.com/playlist?list=PLCrwBqiOtwpIRdk4VMfD6hbFVHZoKOyMg
 
@@ -1266,13 +1267,13 @@
   twitter: kiwirubyconf
   video_link: https://www.youtube.com/playlist?list=PLqR1aFtg6FQKivt1jMU-dotStXiTY11GT
 
-- name: RubyConf
+- name: RubyConf 2017
   location: New Orleans, LA
   start_date: 2017-11-15
   end_date: 2017-11-17
-  url: http://rubyconf.org/
+  url: https://rubyconf.org/
   twitter: rubyconf
-  video_link: http://confreaks.tv/events/rubyconf2017
+  video_link: https://www.youtube.com/playlist?list=PLE7tQUdRKcyayGHjjxZOmVEGsxX-rczZt
 
 - name: RubyConf Brasil
   location: São Paulo, Brazil
@@ -1325,11 +1326,11 @@
   twitter: rubyconfph
   video_link: https://www.youtube.com/playlist?list=PL0mVjsUoElSENtu25MLim42HJszfsXDt2
 
-- name: wroc_love.rb
+- name: wroc_love.rb 2018
   location: Wrocław, Poland
   start_date: 2018-03-16
   end_date: 2018-03-18
-  url: http://wrocloverb.com/
+  url: https://2018.wrocloverb.com
   twitter: wrocloverb
   video_link: https://www.youtube.com/playlist?list=PLoGBNJiQoqRDSMznObXnqyq5HbOqLucTz
 
@@ -1348,13 +1349,13 @@
   url: http://isleofruby.org/
   twitter: isleofruby
 
-- name: RailsConf
+- name: RailsConf 2018
   location: Pittsburgh, PA
   start_date: 2018-04-17
   end_date: 2018-04-19
-  url: https://railsconf.com/
+  url: https://railsconf.com
   twitter: railsconf
-  video_link: https://confreaks.tv/events/railsconf2018
+  video_link: https://www.youtube.com/playlist?list=PLE7tQUdRKcyak-yFKj5IN3tDYOh5omMrH
 
 - name: RubyConfBY
   location: Minsk, Belarus
@@ -1430,7 +1431,7 @@
   end_date: 2018-06-16
   url: http://goruco.com
   twitter: goruco
-  video_link: https://confreaks.tv/events/goruco2018
+  video_link: https://www.youtube.com/playlist?list=PLE7tQUdRKcya2z3Q5AiwNqjV968p2TvHu
 
 - name: Ruby Conf Kenya 2018
   location: Nairobi, Kenya
@@ -1454,11 +1455,11 @@
   twitter: parisrb
   video_link: https://www.youtube.com/playlist?list=PLjyiiigeVQV_mHcSnJnw_1LR4nzGrdF4l
 
-- name: Brighton Ruby Conference
+- name: Brighton Ruby 2018
   location: Brighton, UK
   start_date: 2018-07-06
   end_date: 2018-07-06
-  url: http://brightonruby.com/
+  url: https://brightonruby.com/2018/
   twitter: brightonruby
   video_link: https://brightonruby.com/2018/
 
@@ -1489,7 +1490,7 @@
   location: Vienna, Austria
   start_date: 2018-08-24
   end_date: 2018-08-25
-  url: https://euruko2018.org/
+  url: https://2018.euruko.org
   twitter: euruko
   video_link: https://www.youtube.com/channel/UCSApGhubxla1SMfB8MlryGw/videos
 
@@ -1545,13 +1546,13 @@
   twitter: keeprubyweird
   video_link: http://confreaks.tv/events/keeprubyweird2018
 
-- name: RubyConf
+- name: RubyConf 2018
   location: Los Angeles, CA
   start_date: 2018-11-13
   end_date: 2018-11-15
   url: https://rubyconf.org/
   twitter: rubyconf
-  video_link: http://confreaks.tv/events/rubyconf2018
+  video_link: https://www.youtube.com/playlist?list=PLE7tQUdRKcyZEjH3kIyvIN0eZ4tuVEkBD
 
 - name: RubyConf India
   location: Goa, India
@@ -1592,11 +1593,11 @@
   twitter: rubyoniceconf
   video_link: https://www.youtube.com/playlist?list=PLClLcexm3Iukf--UcFDw_DgKhvKpQEOX-
 
-- name: wroclove.rb
+- name: wroclove.rb 2019
   location: Wrocław, Poland
   start_date: 2019-03-22
   end_date: 2019-03-24
-  url: https://wrocloverb.com/
+  url: https://2019.wrocloverb.com
   twitter: wrocloverb
   video_link: https://www.youtube.com/playlist?list=PLoGBNJiQoqRDJvwOYLuu7jnprRKhuc7Cp
 
@@ -1646,7 +1647,7 @@
   twitter: rubykaigi
   video_link: https://www.youtube.com/playlist?list=PLbFmgWm555yYc9_jx9HkS_1WkOLKWnRw3
 
-- name: RailsConf
+- name: RailsConf 2019
   location: Minneapolis, MN
   start_date: 2019-04-30
   end_date: 2019-05-02
@@ -1696,15 +1697,15 @@
   location: Rotterdam, the Netherlands
   start_date: 2019-06-21
   end_date: 2019-06-22
-  url: https://euruko2019.org/
+  url: https://2019.euruko.org
   twitter: euruko
   video_link: https://www.youtube.com/channel/UCWcOB8yVZDoPGdbvq8HR6IQ/videos
 
-- name: Brighton Ruby
+- name: Brighton Ruby 2019
   location: Brighton, UK
   start_date: 2019-07-05
   end_date: 2019-07-05
-  url: https://brightonruby.com/
+  url: https://brightonruby.com/2019
   twitter: brightonruby
   video_link: https://brightonruby.com/2019/
 
@@ -1714,8 +1715,6 @@
   end_date: 2019-07-27
   url: http://rubyconf.nairuby.org/2019
   twitter: nairubyke
-  cfp_phrase: CFP closes
-  cfp_date: 2019-06-01
 
 - name: Ruby Conf Taiwan 2019
   location: Taipei, Taiwan
@@ -1723,8 +1722,6 @@
   end_date: 2019-07-27
   url: https://2019.rubyconf.tw
   twitter: rubyconftw
-  cfp_phrase: CFP closes
-  cfp_date: 2019-04-25
   video_link: https://www.youtube.com/playlist?list=PLhKZ4RWngmpBgD6t068O_EZ4grSlUtl3Y
 
 - name: Southeast Ruby
@@ -1740,8 +1737,6 @@
   end_date: 2019-08-10
   url: https://www.deccanrubyconf.org/
   twitter: deccanrubyconf
-  cfp_phrase: CFP closes
-  cfp_date: 2019-05-31
 
 - name: GrillRB 2019
   location: Wrocław, Poland
@@ -1751,24 +1746,20 @@
   twitter: grill_rb
   video_link: https://www.youtube.com/playlist?list=PLDraF2Fjmu8WDwr5nInlqNzeiBk9sIsCt
 
-- name: RubyConf TH
+- name: RubyConf TH 2019
   location: Bangkok, Thailand
   start_date: 2019-09-06
   end_date: 2019-09-07
   url: https://rubyconfth.com/
   twitter: rubyconfth
-  cfp_phrase: CFP closes
-  cfp_date: 2019-06-09
   video_link: https://www.youtube.com/playlist?list=PLM_LdV8tMIazzAKhtGxJvYCPCgP8HiB5k
 
-- name: RubyC
+- name: RubyC 2019
   location: Kyiv, Ukraine
   start_date: 2019-09-14
   end_date: 2019-09-15
   url: https://rubyc.eu/
   twitter: rubyc_eu
-  cfp_phrase: CFP closes
-  cfp_date: 2019-03-31
   video_link: https://www.youtube.com/playlist?list=PLmEf5ppiRneTkaPA4fz6KBQKq-jAvTRkb
 
 - name: RubyConf Colombia
@@ -1777,8 +1768,6 @@
   end_date: 2019-09-21
   url: https://rubyconf.co
   twitter: rubyconfco
-  cfp_phrase: CFP closes
-  cfp_date: 2019-06-15
 
 - name: RubyRussia
   location: Moscow, Russia
@@ -1794,8 +1783,6 @@
   end_date: 2019-09-29
   url: https://ruby.id/conf/2019/
   twitter: rubyconfid
-  cfp_phrase: CFP closes
-  cfp_date: 2019-08-11
 
 - name: Ancient City Ruby
   location: Jacksonville Beach, FL
@@ -1803,8 +1790,6 @@
   end_date: 2019-10-04
   url: http://ancientcityruby.com/
   twitter: ancientcityruby
-  cfp_phrase: CFP closes
-  cfp_date: 2019-07-31
   video_link: https://www.youtube.com/playlist?list=PLrjohaqTgNJODBm0-VFsXvUFx1oidLyKa
 
 - name: Pivorak Conf. 4.0
@@ -1837,14 +1822,12 @@
   url: https://2019.rubyworld-conf.org/en/
   twitter: rubyworldconf
 
-- name: RubyConf
+- name: RubyConf 2019
   location: Nashville, TN
   start_date: 2019-11-18
   end_date: 2019-11-20
   url: https://rubyconf.org
   twitter: rubyconf
-  cfp_phrase: CFP closes
-  cfp_date: 2019-08-07
   video_link: https://www.youtube.com/playlist?list=PLE7tQUdRKcyZDE8nFrKaqkpd-XK4huygU
 
 - name: RubyConfBR
@@ -1853,8 +1836,6 @@
   end_date: 2019-11-29
   url: https://callforpapers.locaweb.com.br/events/rubyconf-2019
   twitter: rubyconfbr
-  cfp_phrase: CFP closes
-  cfp_date: 2019-10-06
 
 - name: Birmingham on Rails
   location: Birmingham, Alabama
@@ -1862,20 +1843,14 @@
   end_date: 2020-01-31
   url: http://birminghamonrails.com
   twitter: bhmonrails
-  reg_phrase: "Registration open"
-  reg_date: 2020-01-28
-  cfp_phrase: "CFP open"
-  cfp_date: 2019-12-31
   video_link: https://www.youtube.com/playlist?&list=PLE7tQUdRKcyYC2lZzwTvEeJXghm4Ym4ZX
 
 - name: Rubyfuza
   location: Cape Town, South Africa
   start_date: 2020-02-06
   end_date: 2020-02-08
-  url: http://www.rubyfuza.org
+  url: https://www.rubyfuza.org
   twitter: rubyfuza
-  cfp_phrase: "CFP closes"
-  cfp_date: 2019-12-01
 
 - name: ParisRB Conf
   location: Paris, France
@@ -1931,7 +1906,7 @@
   twitter: rubyconfindia
   status: Canceled
 
-- name: RailsConf 2020.2 COUCH EDITION
+- name: RailsConf 2020.2 Couch Edition
   location: Your Couch
   start_date: 2020-05-05
   end_date: 2020-05-05
@@ -1963,12 +1938,13 @@
   twitter: saintpruby
   status: Canceled
 
-- name: Brighton Ruby Conf
+- name: Brighton Ruby 2020
   location: Online
   start_date: 2020-07-03
   end_date: 2020-07-03
   url: https://brightonruby.com/2020
   twitter: brightonruby
+  video_link: https://brightonruby.com/2020/
 
 - name: RubyNess
   location: Inverness, Scotland
@@ -1993,8 +1969,6 @@
   url: https://www.noruko.org
   twitter: amsrb
   video_link: https://www.youtube.com/playlist?list=PL9_A7olkztLlmJIAc567KQgKcMi7-qnjg
-  cfp_phrase: CFP closes
-  cfp_date: 2020-08-17
 
 - name: RubyKaigi Takeout
   location: Online
@@ -2008,9 +1982,8 @@
   location: Kyiv, Ukraine
   start_date: 2020-09-12
   end_date: 2020-09-13
-  url: http://rubyc.eu/
+  url: https://rubyc.eu/
   twitter: rubyc_eu
-  cfp_phrase: CFP closes
   status: Canceled
 
 - name: RubyDay
@@ -2045,7 +2018,7 @@
   twitter: railsclub_ru
   video_link: https://www.youtube.com/playlist?list=PLiWUIs1hSNeO_YkVRot6JOLgTVSH9uUEB
 
-- name: RubyConf
+- name: RubyConf 2020
   location: Houston, TX
   start_date: 2020-11-17
   end_date: 2020-11-19
@@ -2061,16 +2034,14 @@
   twitter: rubyworldconf
   video_link: https://www.youtube.com/watch?v=2fldr2HcuVw
 
-- name: Rubyday
+- name: Rubyday 2021
   location: Online
   start_date: 2021-04-07
   end_date: 2021-04-07
   url: https://2021.rubyday.it
   twitter: rubydayit
-  cfp_phrase: CFP closes
-  cfp_date: 2021-02-28
 
-- name: RailsConf
+- name: RailsConf 2021
   location: Online
   start_date: 2021-04-12
   end_date: 2021-04-15
@@ -2078,14 +2049,12 @@
   twitter: railsconf
   video_link: https://www.youtube.com/playlist?list=PLbHJudTY1K0c8N1-PPyiQxlHNzJIzyJv6
 
-- name: Euruko
+- name: Euruko 2021
   location: Online
   start_date: 2021-05-28
   end_date: 2021-05-29
-  url: https://euruko2021.org/
+  url: https://2021.euruko.org
   twitter: euruko
-  cfp_phrase: CFP closes
-  cfp_date: 2021-04-18
   video_link: https://www.youtube.com/playlist?list=PLZW-kXE0oRyknRwEUrg5o491KomjkNU16
 
 - name: Saint P Rubyconf
@@ -2134,11 +2103,11 @@
   twitter: railsclub_ru
   video_link: https://www.youtube.com/playlist?list=PLiWUIs1hSNeMfiEGak_zwF_ULP8Rc6HcL
 
-- name: RubyConf
+- name: RubyConf 2021
   location: Denver, CO
   start_date: 2021-11-08
   end_date: 2021-11-10
-  url: http://rubyconf.org
+  url: https://rubyconf.org
   twitter: rubyconf
   video_link: https://www.youtube.com/watch?v=paZ5_3F22V8&list=PLbHJudTY1K0f0oMhWtY-UyzOb7tUlaHps
 
@@ -2148,18 +2117,21 @@
   end_date: 2022-03-25
   url: https://www.sincityruby.com
 
-- name: Railsconf
+- name: Railsconf 2022
   location: Portland, OR
   start_date: 2022-05-17
   end_date: 2022-05-19
   url: https://railsconf.org
   twitter: railsconf
+  video_link: https://www.youtube.com/playlist?list=PLE7tQUdRKcyb2Mjtd1RBjeP3Jt9RukU7G
 
-- name: Brighton Ruby
+- name: Brighton Ruby 2022
   location: Brighton, England
   start_date: 2022-06-30
   end_date: 2022-06-30
-  url: https://brightonruby.com/
+  url: https://brightonruby.com/2022
+  twitter: brightonruby
+  video_link: https://brightonruby.com/2022/
 
 - name: Rails Camp West
   location: Diablo Lake, WA
@@ -2168,22 +2140,21 @@
   url: https://west.railscamp.us/2022
   twitter: railscamp_usa
 
-- name: Euruko
+- name: Euruko 2022
   location: Helsinki, Finland
   start_date: 2022-10-13
   end_date: 2022-10-14
   url: https://2022.euruko.org
   twitter: euruko
-  cfp_phrase: CFP closes
-  cfp_date: 2022-07-10
+  video_link: https://www.youtube.com/playlist?list=PLZW-kXE0oRykcraQ1b6tT5ozKPeK-Jttq
 
-- name: wrocloverb.com
+- name: wroclove.rb 2022
   location: Wrocław, Poland
   start_date: 2022-09-16
   end_date: 2022-09-18
-  url: https://wrocloverb.com/
+  url: https://2022.wrocloverb.com
   twitter: wrocloverb
-  video_link: https://www.youtube.com/user/wrocloverb/videos
+  video_link: https://www.youtube.com/playlist?list=PLoGBNJiQoqRDWafhnWni-CwHkPJJuc0e5
 
 - name: The Rails SaaS Conference
   location: Los Angeles, CA, USA
@@ -2205,19 +2176,21 @@
   url: https://rubykaigi.org/2022
   twitter: rubykaigi
 
-- name: RubyConf Mini, 2022
+- name: RubyConf Mini 2022
   location: Providence, RI, USA
   start_date: 2022-11-15
   end_date: 2022-11-17
   url: https://www.rubyconfmini.com
   twitter: rubyconfmini
+  video_link: https://www.youtube.com/playlist?list=PLE7tQUdRKcyZYz0O3d9ZDdo0-BkOWhrSk
 
-- name: RubyConf, 2022
+- name: RubyConf 2022
   location: Houston, Texas
   start_date: 2022-11-29
   end_date: 2022-12-01
   url: https://rubyconf.org/
   twitter: rubyconf
+  video_link: https://www.youtube.com/playlist?list=PLE7tQUdRKcyZYz0O3d9ZDdo0-BkOWhrSk
 
 - name: RubyConf TH 2022
   location: Bangkok, Thailand
@@ -2225,8 +2198,6 @@
   end_date: 2022-12-10
   url: https://rubyconfth.com/
   twitter: rubyconfth
-  cfp_phrase: CFP closes
-  cfp_date: 2022-09-30
   video_link: https://www.youtube.com/playlist?list=PLM_LdV8tMIaxpMTv9dnWk3cq61xJcE2Pv
 
 - name: Ruby on Rails Global Summit'23
@@ -2235,17 +2206,13 @@
   end_date: 2023-01-25
   url: https://events.geekle.us/ruby/
   twitter: geekleofficial
-  cfp_phrase: CFP open
-  cfp_date: 2022-01-10
 
-- name: RubyConf Australia
+- name: RubyConf Australia 2023
   location: Melbourne, Australia
   start_date: 2023-02-20
   end_date: 2023-02-21
   url: https://www.rubyconf.org.au
   twitter: rubyconf_au
-  cfp_phrase: CFP open
-  cfp_date: 2022-11-14
 
 - name: RailsConf 2023
   location: Atlanta, Georgia
@@ -2253,6 +2220,7 @@
   end_date: 2023-04-26
   url: https://railsconf.org
   twitter: railsconf
+  video_link: https://www.youtube.com/playlist?list=PLE7tQUdRKcyao1oqQA8dwG_uOk3-QZziO
 
 - name: RubyKaigi 2023
   location: Nagano, Japan
@@ -2260,8 +2228,6 @@
   end_date: 2023-05-13
   url: https://rubykaigi.org/2023
   twitter: rubykaigi
-  cfp_phrase: CFP open
-  cfp_date: 2023-01-31
   reg_phrase: Registration open
 
 - name: The Rails SaaS Conference 2023
@@ -2296,12 +2262,10 @@
   location: Brighton, UK
   start_date: 2023-06-30
   end_date: 2023-06-30
-  url: https://brightonruby.com
+  url: https://brightonruby.com/2023/
+  video_link: https://brightonruby.com/2023/
   twitter: brightonruby
   mastodon: https://ruby.social/@brightonruby
-  reg_phrase: Buy tickets!
-  cfp_phrase: CFP open
-  cfp_date: 2023-03-31
 
 - name: Ruby Warsaw Community Conference 2023
   location: Warsaw, Poland
@@ -2332,11 +2296,11 @@
   url: https://regional.rubykaigi.org/osaka03/
   twitter: rubykansai
 
-- name: wroclove.rb
+- name: wroclove.rb 2023
   location: Wrocław, Poland
   start_date: 2023-09-15
   end_date: 2023-09-17
-  url: https://wrocloverb.com/
+  url: https://2023.wrocloverb.com
   twitter: wrocloverb
   video_link: https://www.youtube.com/user/wrocloverb/videos
 
@@ -2353,8 +2317,6 @@
   end_date: 2023-09-23
   url: https://2023.euruko.org
   twitter: euruko
-  cfp_phrase: CFP open
-  cfp_date: 2023-04-01
 
 - name: Friendly.rb
   location: Bucharest, Romania
@@ -2371,7 +2333,6 @@
   end_date: 2023-10-06
   url: https://rubyonrails.org/world
   twitter: rails
-  cfp_phrase: CFP open
 
 - name: Rocky Mountain Ruby
   location: Boulder, Colorado
@@ -2413,8 +2374,6 @@
   url: https://rubyconf.org
   twitter: rubyconf
   mastodon: https://ruby.social/@rubyconf
-  cfp_phrase: CFP closes
-  cfp_date: 2023-08-20
 
 - name: Helvetic Ruby 2023
   location: Bern, Switzerland


### PR DESCRIPTION
* Add year to name of to long-running conferences
* Add video links for conferences
* Fix dead links for videos/conference websites
* use https:// where possible
* Remove unused CFP/reg phrases