### PR TITLE
Fix Balkan Ruby 2024 end date

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -2456,7 +2456,7 @@
 - name: Balkan Ruby 2024
   location: Sofia, Bulgaria
   start_date: 2024-04-26
-  end_date: 2024-04-28
+  end_date: 2024-04-27
   url: https://balkanruby.com
   twitter: balkanruby
 


### PR DESCRIPTION
Reason for Change
=================
Follow up to #545 to fix the end date of the conference

Changes
=======
Update end date of Balkan Ruby 2024

https://balkanruby.com/