### PR TITLE
Add CPF closing date to Ruby Kaigi 2024

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -2490,7 +2490,6 @@
   mastodon: https://ruby.social/@rubykaigi
   cfp_phrase: CFP closes
   cfp_date: 2024-01-31
-  
 
 - name: RubyDay 2024
   location: Verona, Italy

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -2488,6 +2488,9 @@
   url: https://rubykaigi.org
   twitter: rubykaigi
   mastodon: https://ruby.social/@rubykaigi
+  cfp_phrase: CFP closes
+  cfp_date: 2024-01-31
+  
 
 - name: RubyDay 2024
   location: Verona, Italy


### PR DESCRIPTION
Based on the [official site info][ref]

[ref]: https://cfp.rubykaigi.org/events/2024