### PR TITLE
Add `precision` key for events

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ Extra keys for the upcoming events:
 * `reg_date`: If there is a registration deadline, enter that here - ISO8601 formatted (yyyy-mm-dd).
 * `cfp_phrase`: Typically you want to put "CFP open" here. If you also provide a `cfp_date` then you may prefer to write "CFP closes" so the site will render for example "CFP closes in 17 days".
 * `cfp_date`: If there is a cfp deadline, enter that here - ISO8601 formatted (yyyy-mm-dd).
-* `status`:  Typically you want to put "Canceled" or "Postponed" here.
+* `status`:  Typically you want to put "Canceled", "Postponed" or "To be announced" here.
+* `date_precision`: Controls the precision of the `start_date` and `end_date` when the conference dates aren't announced just yet but it's confirmed that the conference is happening. Possible values: `full` (implicit default), `month` or `year`. The `start_date` and `end_date` fields still need to be fully formatted ISO8601 dates, you can put the last day of the month/year in it so it also gets ordered properly.
 
 Extra keys for the past events:
 

--- a/_includes/event.html
+++ b/_includes/event.html
@@ -22,7 +22,11 @@
       {% assign start_year = event.start_date | date: '%Y' %}
       {% assign end_year = event.end_date | date: '%Y' %}
 
-      {% if event.start_date == event.end_date %}
+      {% if event.date_precision == 'month' %}
+        {{ event.start_date | date: '%B %Y' }}
+      {% elsif event.date_precision == 'year' %}
+        {{ event.start_date | date: '%Y' }}
+      {% elsif event.start_date == event.end_date %}
         {{ event.start_date | date: '%B %-d, %Y' }}
       {% elsif start_month == end_month %}
         {{ event.start_date | date: '%B %-d' }}–{{ event.end_date | date: '%-d, %Y' }}


### PR DESCRIPTION
This pull request adds a `date_precision` key to events.

This config can be useful for the case when we know a specific conference is confirmed to happen and when we don't know the specific dates yet.

A good current example is RubyConf 2024, we know it's usually happening in the US in November, but we don't have specific dates just yet.

With the `date_precision` we can do something like this to still have it listed on the site, even without having the details just yet:

```diff
 - name: RubyConf 2024
   location: United States of America
   start_date: 2024-11-30
   end_date: 2024-11-30
+  date_precision: month
+  status: To be announced
   # ...
```

So it shows up like this on the website:

![CleanShot 2024-01-21 at 12 01 44@2x](https://github.com/ruby-conferences/ruby-conferences.github.io/assets/6411752/ce3a3f0f-9d09-48ae-891f-c3119619c60c)
