### PR TITLE
Add `cfp_link` key for events

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ Extra keys for the upcoming events:
 * `reg_phrase`: Typically you want to put "Registration open" here.
 * `reg_date`: If there is a registration deadline, enter that here - ISO8601 formatted (yyyy-mm-dd).
 * `cfp_phrase`: Typically you want to put "CFP open" here. If you also provide a `cfp_date` then you may prefer to write "CFP closes" so the site will render for example "CFP closes in 17 days".
-* `cfp_date`: If there is a cfp deadline, enter that here - ISO8601 formatted (yyyy-mm-dd).
+* `cfp_date`: If there is a CFP deadline, enter that here - ISO8601 formatted (yyyy-mm-dd).
+* `cfp_link`: A link to the CFP submission page.
 * `status`:  Typically you want to put "Canceled", "Postponed" or "To be announced" here.
 * `date_precision`: Controls the precision of the `start_date` and `end_date` when the conference dates aren't announced just yet but it's confirmed that the conference is happening. Possible values: `full` (implicit default), `month` or `year`. The `start_date` and `end_date` fields still need to be fully formatted ISO8601 dates, you can put the last day of the month/year in it so it also gets ordered properly.
 

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -2421,8 +2421,7 @@
   end_date: 2024-02-04
   twitter: rubybelgium
   url: https://fosdem.rubybelgium.be
-  cfp_phrase: CFP closes
-  cfp_date: 2023-12-01
+  cfp_phrase: CFP closed
 
 - name: Ruby Warsaw Community Conference 2024
   location: Warsaw, Poland
@@ -2443,8 +2442,7 @@
   end_date: 2024-04-05
   url: https://www.tropicalrb.com/
   twitter: tropical_rb
-  cfp_phrase: CFP closes
-  cfp_date: 2024-01-10
+  cfp_phrase: CFP closed
   mastodon: https://ruby.social/@tropicalrb
 
 - name: RubyConf AU 2024
@@ -2453,8 +2451,7 @@
   end_date: 2024-04-12
   url: https://rubyconf.org.au/
   twitter: rubyconf_au
-  cfp_phrase: CFP closes
-  cfp_date: 2024-01-12
+  cfp_phrase: CFP closed
 
 - name: wroclove.rb 2024
   location: Wrocław, Poland
@@ -2465,6 +2462,7 @@
   mastodon: https://ruby.social/@wrocloverb/
   cfp_phrase: CFP closes
   cfp_date: 2024-01-31
+  cfp_link: https://forms.gle/bgTVhWZzjRV74F1x7
 
 - name: Balkan Ruby 2024
   location: Sofia, Bulgaria
@@ -2474,6 +2472,7 @@
   twitter: balkanruby
   cfp_phrase: CFP closes
   cfp_date: 2024-02-02
+  cfp_link: https://forms.gle/NJY9PJWpud39ZQAr8
 
 - name: RailsConf 2024
   location: Detroit, MI
@@ -2487,11 +2486,12 @@
   location: Naha, Okinawa, Japan
   start_date: 2024-05-15
   end_date: 2024-05-17
-  url: https://rubykaigi.org
+  url: https://rubykaigi.org/2024
   twitter: rubykaigi
   mastodon: https://ruby.social/@rubykaigi
   cfp_phrase: CFP closes
   cfp_date: 2024-01-31
+  cfp_link: https://cfp.rubykaigi.org/events/2024
 
 - name: Helvetic Ruby 2024
   location: Zurich, Switzerland
@@ -2502,6 +2502,7 @@
   mastodon: https://ruby.social/@helvetic_ruby
   cfp_phrase: CFP closes
   cfp_date: 2024-02-25
+  cfp_link: https://helvetic-ruby.ch/call-for-speakers
 
 - name: Blue Ridge Ruby 2024
   location: Asheville, NC, USA
@@ -2512,15 +2513,17 @@
   mastodon: https://ruby.social/@blueridgeruby
   cfp_phrase: CFP closes
   cfp_date: 2024-03-01
+  cfp_link: https://blueridgeruby.com/cfp
 
 - name: RubyDay 2024
   location: Verona, Italy
   start_date: 2024-05-31
   end_date: 2024-05-31
-  cfp_phrase: CFP closes
-  cfp_date: 2024-01-31
   url: https://2024.rubyday.it
   twitter: rubydayit
+  cfp_phrase: CFP closes
+  cfp_date: 2024-01-31
+  cfp_link: https://2024.rubyday.it/welcome/cfp.html
 
 - name: Baltic Ruby 2024
   location: Malmö, Sweden
@@ -2545,6 +2548,7 @@
   mastodon: https://ruby.social/@brightonruby
   cfp_phrase: CFP closes
   cfp_date: 2024-02-29
+  cfp_link: https://forms.reform.app/goodscary/brighton-ruby-2024-cfp/gci0d6
 
 - name: Madison+ Ruby 2024
   location: Madison, WI
@@ -2562,6 +2566,7 @@
   mastodon: https://ruby.social/@Euruko
   cfp_phrase: CFP closes
   cfp_date: 2024-04-15
+  cfp_link: https://www.papercall.io/euruko2024
 
 - name: Friendly.rb 2024
   location: Bucharest, Romania

--- a/_includes/event.html
+++ b/_includes/event.html
@@ -10,7 +10,10 @@
   {% if event.reg_phrase %}
   <div class="reg" data-date="{{ event.reg_date }}" data-phrase="{{ event.reg_phrase }}"></div>
   {% endif %}
-  {% if event.cfp_phrase %}
+
+  {% if event.cfp_phrase and event.cfp_link %}
+  <a class="cfp cfp-link" href="{{ event.cfp_link }}" data-date="{{ event.cfp_date }}" data-phrase="{{ event.cfp_phrase }}" target="_blank"></a>
+  {% elsif event.cfp_phrase %}
   <div class="cfp" data-date="{{ event.cfp_date }}" data-phrase="{{ event.cfp_phrase }}"></div>
   {% endif %}
 </dt>

--- a/css/style.css
+++ b/css/style.css
@@ -320,6 +320,10 @@ header {
 #news footer .older {
   float: right; }
 
-.cfp-link:hover {
+.cfp-link {
   text-decoration: underline;
+}
+
+.cfp-link:hover {
+  color: black !important;
 }

--- a/css/style.css
+++ b/css/style.css
@@ -319,3 +319,7 @@ header {
 /* line 213, /Users/jon/code/rc/site/source/css/style.sass */
 #news footer .older {
   float: right; }
+
+.cfp-link:hover {
+  text-decoration: underline;
+}


### PR DESCRIPTION
This pull request adds a `cfp_link` key to the events.

The `cfp_link` key can be used to link to the CFP submission page or the CFP platform so that speakers looking to submit a talk can easily get to the relevant page.

If an event has a `cfp_link` it will render the CFP phrase with an underline:

![CleanShot 2024-01-21 at 13 02 03@2x](https://github.com/ruby-conferences/ruby-conferences.github.io/assets/6411752/f93c17ba-d8d0-4ff7-957d-af0caa672867)
