### PR TITLE
Add /cfp/ for open and coming CFPs

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -22,6 +22,7 @@
           <ul>
             <li class="{% if page.url == "/" %}active{% endif %}"><a href="/">Upcoming</a></li>
             <li class="{% if page.url == "/past/" %}active{% endif %}"><a href="/past/">Past</a></li>
+            <li class="{% if page.url == "/cfp/" %}active{% endif %}"><a href="/cfp/">CFP</a></li>
           </ul>
         </nav>
       </header>

--- a/cfp/index.html
+++ b/cfp/index.html
@@ -1,0 +1,16 @@
+---
+layout: default
+---
+<article id="home">
+  <dl>
+    {% assign now = site.time | date: '%s' | plus: 0 %}
+    {% assign conferences = site.data.conferences | sort: 'start_date' %}
+    {% for event in conferences %}
+      {% assign start_date = event.start_date | date: '%s' | plus: 0 %}
+      {% assign cfp_date = event.cfp_date | date: '%s' | plus: 0 %}
+      {% if start_date > now and cfp_date > now %}
+        {% include event.html %}
+      {% endif %}
+    {% endfor %}
+  </dl>
+</article>


### PR DESCRIPTION
Figured it was about time we had a simple place to see open and forthcoming CFPs.

Hence the addition of `/cfp/`.

Didn't need much other than the new template and a link in the header.

### Future improvements

We might want to include the ability to filter by _open_ CFPs as well as _forthcoming_ ones?

Closes #553 I think.