### PR TITLE
Introduce `cfp_open_date` and `cfp_close_date`

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ Extra keys for the upcoming events:
 
 * `reg_phrase`: Typically you want to put "Registration open" here.
 * `reg_date`: If there is a registration deadline, enter that here - ISO8601 formatted (yyyy-mm-dd).
-* `cfp_phrase`: Typically you want to put "CFP open" here. If you also provide a `cfp_date` then you may prefer to write "CFP closes" so the site will render for example "CFP closes in 17 days".
-* `cfp_date`: If there is a CFP deadline, enter that here - ISO8601 formatted (yyyy-mm-dd).
+* `cfp_open_date`: The date when the CFP was opened - ISO8601 formatted (yyyy-mm-dd).
+* `cfp_close_date`: If there is a CFP deadline, enter that here - ISO8601 formatted (yyyy-mm-dd).
 * `cfp_link`: A link to the CFP submission page.
 * `status`:  Typically you want to put "Canceled", "Postponed" or "To be announced" here.
 * `date_precision`: Controls the precision of the `start_date` and `end_date` when the conference dates aren't announced just yet but it's confirmed that the conference is happening. Possible values: `full` (implicit default), `month` or `year`. The `start_date` and `end_date` fields still need to be fully formatted ISO8601 dates, you can put the last day of the month/year in it so it also gets ordered properly.

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -2363,10 +2363,10 @@
   end_date: 2023-10-07
   url: https://rubyconfth.com/
   twitter: rubyconfth
-  cfp_phrase: CFP closes
-  cfp_date: 2023-06-04
-  reg_phrase: Buy tickets!
   mastodon: https://ruby.social/@rubyconfth
+  cfp_open_date: 2023-04-03
+  cfp_close_date: 2023-06-04
+  cfp_link: https://www.papercall.io/rubyconfth2023
   video_link: https://www.youtube.com/playlist?list=PLM_LdV8tMIay0GaJcCHegGyk0MGyQIVA6
 
 - name: Ruby Retreat 2023
@@ -2412,8 +2412,9 @@
   end_date: 2023-12-16
   twitter: rubyconftw
   url: https://2023.rubyconf.tw
-  cfp_phrase: CFP open
-  cfp_date: 2023-10-20
+  cfp_open_date: 2023-08-03
+  cfp_close_date: 2023-10-20
+  cfp_link: https://cfp.rubyconf.tw/activities/2023
 
 - name: Ruby devroom at FOSDEM 2024
   location: Brussels, Belgium
@@ -2421,7 +2422,8 @@
   end_date: 2024-02-04
   twitter: rubybelgium
   url: https://fosdem.rubybelgium.be
-  cfp_phrase: CFP closed
+  cfp_close_date: 2023-12-01
+  cfp_link: https://pretalx.fosdem.org/fosdem-2024/cfp
 
 - name: Ruby Warsaw Community Conference 2024
   location: Warsaw, Poland
@@ -2436,14 +2438,16 @@
   end_date: 2024-03-22
   url: https://www.sincityruby.com
 
-- name: Tropical.rb
+- name: Tropical.rb 2024
   location: São Paulo, Brazil
   start_date: 2024-04-04
   end_date: 2024-04-05
   url: https://www.tropicalrb.com/
   twitter: tropical_rb
-  cfp_phrase: CFP closed
   mastodon: https://ruby.social/@tropicalrb
+  cfp_open_date: 2023-11-28
+  cfp_close_date: 2024-01-10
+  cfp_link: https://www.papercall.io/tropical-rb
 
 - name: RubyConf AU 2024
   location: Sydney, Australia
@@ -2451,7 +2455,9 @@
   end_date: 2024-04-12
   url: https://rubyconf.org.au/
   twitter: rubyconf_au
-  cfp_phrase: CFP closed
+  cfp_open_date: 2023-11-14
+  cfp_close_date: 2024-01-12
+  cfp_link: https://sessionize.com/rubyconf-au-2024
 
 - name: wroclove.rb 2024
   location: Wrocław, Poland
@@ -2460,8 +2466,8 @@
   url: https://2024.wrocloverb.com
   twitter: wrocloverb
   mastodon: https://ruby.social/@wrocloverb/
-  cfp_phrase: CFP closes
-  cfp_date: 2024-01-31
+  cfp_open_date: 2023-12-11
+  cfp_close_date: 2024-01-31
   cfp_link: https://forms.gle/bgTVhWZzjRV74F1x7
 
 - name: Balkan Ruby 2024
@@ -2470,8 +2476,8 @@
   end_date: 2024-04-27
   url: https://balkanruby.com
   twitter: balkanruby
-  cfp_phrase: CFP closes
-  cfp_date: 2024-02-02
+  cfp_open_date: 2023-11-20
+  cfp_close_date: 2024-02-02
   cfp_link: https://forms.gle/NJY9PJWpud39ZQAr8
 
 - name: RailsConf 2024
@@ -2481,8 +2487,8 @@
   url: https://www.railsconf.com
   twitter: railsconf
   mastodon: https://ruby.social/@railsconf
-  cfp_phrase: CFP closes
-  cfp_date: 2024-02-13
+  cfp_open_date: 2024-01-24
+  cfp_close_date: 2024-02-13
   cfp_link: https://sessionize.com/railsconf2024
 
 - name: RubyKaigi 2024
@@ -2492,8 +2498,8 @@
   url: https://rubykaigi.org/2024
   twitter: rubykaigi
   mastodon: https://ruby.social/@rubykaigi
-  cfp_phrase: CFP closes
-  cfp_date: 2024-01-31
+  cfp_open_date: 2023-12-25
+  cfp_close_date: 2024-01-31
   cfp_link: https://cfp.rubykaigi.org/events/2024
 
 - name: Helvetic Ruby 2024
@@ -2503,8 +2509,8 @@
   url: https://helvetic-ruby.ch
   twitter: helvetic_ruby
   mastodon: https://ruby.social/@helvetic_ruby
-  cfp_phrase: CFP closes
-  cfp_date: 2024-02-25
+  cfp_open_date: 2024-01-19
+  cfp_close_date: 2024-02-25
   cfp_link: https://helvetic-ruby.ch/call-for-speakers
 
 - name: Blue Ridge Ruby 2024
@@ -2514,8 +2520,8 @@
   url: https://blueridgeruby.com
   twitter: blueridgeruby
   mastodon: https://ruby.social/@blueridgeruby
-  cfp_phrase: CFP closes
-  cfp_date: 2024-03-01
+  cfp_open_date: 2024-01-18
+  cfp_close_date: 2024-03-01
   cfp_link: https://blueridgeruby.com/cfp
 
 - name: RubyDay 2024
@@ -2524,8 +2530,8 @@
   end_date: 2024-05-31
   url: https://2024.rubyday.it
   twitter: rubydayit
-  cfp_phrase: CFP closes
-  cfp_date: 2024-01-31
+  cfp_open_date: 2023-11-03
+  cfp_close_date: 2024-01-31
   cfp_link: https://2024.rubyday.it/welcome/cfp.html
 
 - name: Baltic Ruby 2024
@@ -2550,8 +2556,8 @@
   url: https://brightonruby.com
   twitter: brightonruby
   mastodon: https://ruby.social/@brightonruby
-  cfp_phrase: CFP closes
-  cfp_date: 2024-02-29
+  cfp_open_date: 2024-01-21
+  cfp_close_date: 2024-02-29
   cfp_link: https://forms.reform.app/goodscary/brighton-ruby-2024-cfp/gci0d6
 
 - name: Madison+ Ruby 2024
@@ -2568,8 +2574,8 @@
   url: https://2024.euruko.org
   twitter: euruko
   mastodon: https://ruby.social/@Euruko
-  cfp_phrase: CFP closes
-  cfp_date: 2024-04-15
+  cfp_open_date: 2024-01-12
+  cfp_close_date: 2024-04-15
   cfp_link: https://www.papercall.io/euruko2024
 
 - name: Friendly.rb 2024
@@ -2586,8 +2592,8 @@
   end_date: 2024-09-27
   url: https://rubyonrails.org/world
   twitter: rails
-  cfp_phrase: CFP closes
-  cfp_date: 2024-03-21
+  cfp_open_date: 2024-02-05
+  cfp_close_date: 2024-03-21
   cfp_link: https://sessionize.com/rails-world/
 
 - name: Rubyfuza 2024

--- a/_includes/event.html
+++ b/_includes/event.html
@@ -1,22 +1,36 @@
 <dt>
   {% if event.url %}
-  <a href="{{ event.url }}">{{ event.name }}</a>
+    <a href="{{ event.url }}">{{ event.name }}</a>
   {% else %}
-  <a>{{ event.name }}</a>
-  {% endif %}
-  {% if event.status %}
-  <div class="status" data-phrase="{{ event.status }}"></div>
-  {% endif %}
-  {% if event.reg_phrase %}
-  <div class="reg" data-date="{{ event.reg_date }}" data-phrase="{{ event.reg_phrase }}"></div>
+    <a>{{ event.name }}</a>
   {% endif %}
 
-  {% if event.cfp_phrase and event.cfp_link %}
-  <a class="cfp cfp-link" href="{{ event.cfp_link }}" data-date="{{ event.cfp_date }}" data-phrase="{{ event.cfp_phrase }}" target="_blank"></a>
-  {% elsif event.cfp_phrase %}
-  <div class="cfp" data-date="{{ event.cfp_date }}" data-phrase="{{ event.cfp_phrase }}"></div>
+  {% if event.status %}
+    <div class="status" data-phrase="{{ event.status }}"></div>
+  {% endif %}
+
+  {% if event.reg_phrase %}
+    <div class="reg" data-date="{{ event.reg_date }}" data-phrase="{{ event.reg_phrase }}"></div>
+  {% endif %}
+
+  {% assign cfp_open_date = event.cfp_open_date | date: '%s' | plus: 0 %}
+  {% assign cfp_close_date = event.cfp_close_date | date: '%s' | plus: 0 %}
+
+  {% if event.cfp_open_date and cfp_open_date > now %}
+    {% if event.cfp_link %}
+      <a class="cfp cfp-link" href="{{ event.cfp_link }}" data-date="{{ event.cfp_open_date }}" data-phrase="{% if cfp_open_date > now %}CFP opens{% else %}CFP opened{% endif %}" target="_blank"></a>
+    {% elsif event.cfp_open_date %}
+      <div class="cfp" data-date="{{ event.cfp_open_date }}" data-phrase="{% if cfp_open_date > now %}CFP opens{% else %}CFP opened{% endif %}"></div>
+    {% endif %}
+  {% elsif event.cfp_close_date %}
+    {% if event.cfp_link %}
+      <a class="cfp cfp-link" href="{{ event.cfp_link }}" data-date="{{ event.cfp_close_date }}" data-phrase="{% if cfp_close_date > now %}CFP closes{% else %}CFP closed{% endif %}" target="_blank"></a>
+    {% elsif event.cfp_close_date %}
+      <div class="cfp" data-date="{{ event.cfp_close_date }}" data-phrase="{% if cfp_close_date > now %}CFP closes{% else %}CFP closed{% endif %}"></div>
+    {% endif %}
   {% endif %}
 </dt>
+
 <dd>
   <ul>
     <li>

--- a/cfp/index.html
+++ b/cfp/index.html
@@ -4,10 +4,10 @@ layout: default
 <article id="home">
   <dl>
     {% assign now = site.time | date: '%s' | plus: 0 %}
-    {% assign conferences = site.data.conferences | sort: 'start_date' %}
+    {% assign conferences = site.data.conferences | sort: 'cfp_close_date' %}
     {% for event in conferences %}
       {% assign start_date = event.start_date | date: '%s' | plus: 0 %}
-      {% assign cfp_date = event.cfp_date | date: '%s' | plus: 0 %}
+      {% assign cfp_date = event.cfp_close_date | date: '%s' | plus: 0 %}
       {% if start_date >= now and cfp_date >= now %}
         {% include event.html %}
       {% endif %}


### PR DESCRIPTION
In favor of `cfp_date` and `cfp_phrase`.

~We might want to think about making the dates UTC timestamps, at least for the `cfp_close_date`.~

This pull request also updates the sort order for the CFP tab, so now the CFP close dates are in order:

![CleanShot 2024-02-06 at 02 40 03](https://github.com/ruby-conferences/ruby-conferences.github.io/assets/6411752/7e6c9915-db32-4cf7-b4dc-76ffe3448e68)


