### PR TITLE
Add experimental timeline view

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -23,6 +23,7 @@
             <li class="{% if page.url == "/" %}active{% endif %}"><a href="/">Upcoming</a></li>
             <li class="{% if page.url == "/past/" %}active{% endif %}"><a href="/past/">Past</a></li>
             <li class="{% if page.url == "/cfp/" %}active{% endif %}"><a href="/cfp/">CFP</a></li>
+            <li class="{% if page.url == "/timeline/" %}active{% endif %}"><a href="/timeline/">Timeline</a></li>
           </ul>
         </nav>
       </header>

--- a/timeline/index.html
+++ b/timeline/index.html
@@ -1,0 +1,41 @@
+---
+layout: default
+---
+
+<article id="home">
+  <pre class="mermaid">
+    gantt
+        dateFormat  YYYY-MM-DD
+
+    {% assign beginningOfYear = site.time | date: "%Y-01-01" | date: '%s' | plus: 0 -%}
+    {% assign now = site.time | date: '%s' | plus: 0 -%}
+    {% assign conferences = site.data.conferences | sort: "start_date" -%}
+    {%- for event in conferences -%}
+      {% assign start_date = event.start_date | date: '%s' | plus: 0 -%}
+      {%- assign dateStart = event.start_date | date: '%s' -%}
+      {%- assign dateEnd = event.end_date | date: '%s' -%}
+      {%- assign diffSeconds = dateEnd | minus: dateStart -%}
+      {%- assign diffDays = diffSeconds | divided_by: 3600 | divided_by: 24 | at_least: 1 %}
+      {%- if start_date >= beginningOfYear %}
+        {{ event.name | replace: "#", "#35;" | replace: ":", "#58;" }} {% if start_date >= now %}:active{% else %}:done{%endif%}, {{ event.name | slugify: "ascii" | replace: "-", "" }}, {{ event.start_date | date: '%Y-%m-%d' }}, {{ diffDays }}d
+      {%- endif -%}
+    {% endfor %}
+
+    {% for event in conferences -%}
+      {% assign start_date = event.start_date | date: '%s' | plus: 0 -%}
+      {%- if start_date >= beginningOfYear %}
+        click {{ event.name | slugify: "ascii" | replace: "-", "" }} href "{{ event.url }}"
+      {%- endif -%}
+    {% endfor -%}
+  </pre>
+
+  <script type="module">
+    import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs';
+    mermaid.initialize({
+      theme: 'neutral',
+      themeVariables: {
+        sectionBkgColor: 'rgba(153, 153, 153, 0)',
+      }
+    });
+  </script>
+</article>


### PR DESCRIPTION
Add an experimental timeline view of the conferences

![Gantt chart of upcoming conferences](https://github.com/ruby-conferences/ruby-conferences.github.io/assets/43314/9df87289-a4f0-45c6-8813-bf208fbf4838)

Reason for Change
=================

* There are a lot of upcoming conferences so visualising what's taking place when is a bit hard
* This also makes it easier to spot events that overlap

Changes
=======

* Adds a Mermaid Gantt chart of the current year's events
* There's still work to be done here before this is ready for production, among other things:
    * [ ] Fix the chart colours
    * [ ] Fix the chart font
    * [ ] Self-host the mermaid JS file
    * [ ] Event name escaping is a bit hacky at the moment but I couldn't figure out a better way to do it with Liquid/Jekyll
    * [ ] Figure out if there's a better library to use for the chart

Minor
-----

* —

