### PR TITLE
Update conferences.yml with Rails World CFP link

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -2586,10 +2586,9 @@
   end_date: 2024-09-27
   url: https://rubyonrails.org/world
   twitter: rails
-  cfp_phrase: CFP opens
-  cfp_date: 2024-02-05
-  # cfp_phrase: CFP closes
-  # cfp_date: 2024-03-21
+  cfp_phrase: CFP closes
+  cfp_date: 2024-03-21
+  cfp_link: https://sessionize.com/rails-world/
 
 - name: Rubyfuza 2024
   location: Cape Town, South Africa


### PR DESCRIPTION
Title

Reason for Change
=================
Rails World CFP link is now live.

Changes
=======
* Add link
* Activate closing date
* Remove 'CFP opens' date

Minor
-----
*

https://sessionize.com/rails-world/
