### PR TITLE
Add location for RubyConf 2024

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -2598,7 +2598,7 @@
   twitter: rubyfuza
 
 - name: RubyConf 2024
-  location: United States of America
+  location: Chicago, IL
   start_date: 2024-11-30
   end_date: 2024-11-30
   date_precision: month


### PR DESCRIPTION
Reason for Change
=================
Location for RubyConf 2024 announced [by Ruby Central & thoughtbot](https://thoughtbot.com/blog/ruby-and-rails-conferences-in-2024)

Changes
=======
Add location for Ruby Central RubyConf 2024
