### PR TITLE
Add Ruby in Common 2024

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -2445,6 +2445,12 @@
   cfp_phrase: CFP closed
   mastodon: https://ruby.social/@tropicalrb
 
+- name: Ruby in Common 2024
+  location: Sydney, Australia
+  start_date: 2024-04-10
+  end_date: 2024-04-10
+  url: https://rubyincommon.org/
+
 - name: RubyConf AU 2024
   location: Sydney, Australia
   start_date: 2024-04-11


### PR DESCRIPTION
[A new event I'm running](https://rubyincommon.org), this one taking place the day before RubyConf AU. Since this is an independent, whole day, ticketed event, I think it reasonably qualifies for "conference" status :)
