### PR TITLE
Add RedDotRubyConf 2024

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -2640,3 +2640,14 @@
   url: https://rubyconf.org
   twitter: rubyconf
   mastodon: https://ruby.social/@rubyconf
+
+- name: RedDotRubyConf 2024
+  location: Singapore
+  start_date: 2024-07-25
+  end_date: 2024-07-26
+  url: https://reddotrubyconf.com
+  twitter: reddotrubyconf
+  mastodon: https://ruby.social/@reddotrubyconf
+  cfp_phrase: CFP closes
+  cfp_date: 2024-06-01
+  cfp_link: https://reddotrubyconf.com/papers/new


### PR DESCRIPTION
Reason for Change
=================
* RedDotRuby Conference is back! 🥳

Changes
=======
* Add the conference.

<img width="614" alt="Screenshot 2024-03-23 at 10 50 20 AM" src="https://github.com/ruby-conferences/ruby-conferences.github.io/assets/5259935/d76e5d2b-44b7-4266-bf65-7ba13dd43f53">
