### PR TITLE
adding meetup info AustinRB/Austin On Rails for the month of May

### DIFF
--- a/_data/meetups.yml
+++ b/_data/meetups.yml
@@ -277,7 +277,7 @@
   start_time: 19:00:00 CEST
   end_time: 20:30:00 CEST
   url: https://www.meetup.com/geneva-rb/events/299288843
-
+  
 - name: NYC.rb - Mob Programming - Turbo!
   location: Online
   date: 2024-05-15
@@ -452,3 +452,18 @@
   start_time: 19:00:00 CET
   end_time: 21:30:00 CET
   url: https://www.rug-b.de/events/february-meetup-2024-769
+
+- name: AustinRB/Austin on Rails - Debugging with ruby/debug
+  location: Austin, TX
+  date: 2024-05-14
+  start_time: 18:30:00 CDT
+  end_time: 20:30:00 CDT
+  url: https://www.meetup.com/austinrb/events/297610740/
+
+- name: AustinRB/Austin on Rails - Ruby Social (Morning)
+  location: Austin, TX
+  date: 2024-05-30
+  start_time: 08:00:00 CDT
+  end_time: 10:00:00 CDT
+  url: https://www.meetup.com/austinrb/events/300256914/
+  

--- a/_data/meetups.yml
+++ b/_data/meetups.yml
@@ -277,7 +277,14 @@
   start_time: 19:00:00 CEST
   end_time: 20:30:00 CEST
   url: https://www.meetup.com/geneva-rb/events/299288843
-  
+
+- name: AustinRB/Austin on Rails - Debugging with ruby/debug
+  location: Austin, TX
+  date: 2024-05-14
+  start_time: 18:30:00 CDT
+  end_time: 20:30:00 CDT
+  url: https://www.meetup.com/austinrb/events/297610740
+
 - name: NYC.rb - Mob Programming - Turbo!
   location: Online
   date: 2024-05-15
@@ -305,6 +312,13 @@
   start_time: 17:30:00 EDT
   end_time: 20:30:00 EDT
   url: https://lu.ma/cbeeanbk
+
+- name: AustinRB/Austin on Rails - Ruby Social (Morning)
+  location: Austin, TX
+  date: 2024-05-30
+  start_time: 08:00:00 CDT
+  end_time: 10:00:00 CDT
+  url: https://www.meetup.com/austinrb/events/300256914
 
 - name: Paris.rb
   location: Paris, France
@@ -452,18 +466,3 @@
   start_time: 19:00:00 CET
   end_time: 21:30:00 CET
   url: https://www.rug-b.de/events/february-meetup-2024-769
-
-- name: AustinRB/Austin on Rails - Debugging with ruby/debug
-  location: Austin, TX
-  date: 2024-05-14
-  start_time: 18:30:00 CDT
-  end_time: 20:30:00 CDT
-  url: https://www.meetup.com/austinrb/events/297610740/
-
-- name: AustinRB/Austin on Rails - Ruby Social (Morning)
-  location: Austin, TX
-  date: 2024-05-30
-  start_time: 08:00:00 CDT
-  end_time: 10:00:00 CDT
-  url: https://www.meetup.com/austinrb/events/300256914/
-  


### PR DESCRIPTION
Title Add AustinRB/Austin on Rails May Meetups

Reason for Change
=================
* adding may events for austin ruby meetups

Changes
=======
* added tech talk and social event

