### PR TITLE
Change the closing date for RubyConfAfrica

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -2634,7 +2634,7 @@
   url: https://rubyconf.africa/
   twitter: ruby_african
   cfp_open_date: 2024-03-20
-  cfp_close_date: 2024-05-31
+  cfp_close_date: 2024-07-20
   cfp_link: https://www.papercall.io/rubyconfafrica2024
 
 - name: Madison+ Ruby 2024


### PR DESCRIPTION
Change the closing date for RubyConfAfrica

Reason for Change
=================
* In order to attract more speakers, we have decided to extend the closing date for CFP due to the low number of submitted proposals.

Changes
=======
* Change the closing date to 2024-07-20
