### PR TITLE
Add SF Bay area meetup in July

### DIFF
--- a/_data/meetups.yml
+++ b/_data/meetups.yml
@@ -872,3 +872,10 @@
   start_time: 18:00:00 BST
   end_time: 20:00:00 BST
   url: https://lrug.org/meetings/2024/june
+
+- name: SF Bay Area Ruby Meetup in July @ Cisco Meraki
+  location: San Francisco, CA
+  date: 2024-07-18
+  start_time: 17:00:00 PDT
+  end_time: 21:00:00 PDT
+  url: https://lu.ma/bxzdp6mz


### PR DESCRIPTION
Adding the next SF Bay Area Ruby meetup in July.
I could mess up, please take a look.