### PR TITLE
Add Baltic Ruby 2025

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -2762,3 +2762,13 @@
   url: https://helvetic-ruby.ch
   twitter: helvetic_ruby
   mastodon: https://ruby.social/@helvetic_ruby
+
+- name: Baltic Ruby 2025
+  location: Riga, Latvia
+  # TODO: update when dates are confirmed
+  start_date: 2025-06-30
+  end_date: 2025-06-30
+  date_precision: month
+  url: https://balticruby.org/balticruby2025
+  twitter: balticruby
+  mastodon: https://ruby.social/@balticruby


### PR DESCRIPTION
Baltic Ruby 2025 is scheduled for Summer 2025. We are adding the conference with a `date_precision` of `month` so it doesn't show exact dates. 

https://balticruby.org/balticruby2025

![CleanShot 2024-06-18 at 14 19 28@2x](https://github.com/ruby-conferences/ruby-conferences.github.io/assets/6411752/3aa5ae38-cae4-43d0-89ee-57eef539c9dc)
