### PR TITLE
Add RailsConf 2025

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -2780,3 +2780,13 @@
   url: https://balticruby.org/balticruby2025
   twitter: balticruby
   mastodon: https://ruby.social/@balticruby
+
+- name: RailsConf 2025
+  location: United States
+  # TODO: update when dates are confirmed
+  start_date: 2025-12-31
+  end_date: 2025-12-31
+  date_precision: year
+  url: https://www.railsconf.com
+  twitter: railsconf
+  mastodon: https://ruby.social/@railsconf


### PR DESCRIPTION
https://rubycentral.org/news/anewearforrubycentralevents

The event has `date_precision` set to `year` so it doesn't show an explicit date:

![CleanShot 2024-06-22 at 00 14 51](https://github.com/ruby-conferences/ruby-conferences.github.io/assets/6411752/0b300461-04ff-4c9c-94a4-6d033a26595e)
