### PR TITLE
BalticRuby 2025 link points to the main site

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -2782,7 +2782,7 @@
   start_date: 2025-06-30
   end_date: 2025-06-30
   date_precision: month
-  url: https://balticruby.org/balticruby2025
+  url: https://balticruby.org
   twitter: balticruby
   mastodon: https://ruby.social/@balticruby
 


### PR DESCRIPTION
Info about BalticRuby 2025 Conference will be on the main page, but the previous edition we will later publish on the separate space. Also will update historical link here. 