### PR TITLE
Add mastodon link for Haggis Ruby

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -2741,6 +2741,7 @@
   start_date: 2024-10-24
   end_date: 2024-10-24
   url: https://haggisruby.co.uk
+  mastodon: https://ruby.social/@haggisruby
 
 - name: Kaigi on Rails 2024
   location: Tokyo, Japan


### PR DESCRIPTION
Add Mastodon link for Haggis Ruby conference

Reason for Change
=================
* We recently created a mastodon account for the conference, so adding that in the yaml file

Changes
=======
* added mastodon key in `_data/conferences.yml` to link to haggisruby account

