### PR TITLE
Add an Atom feed to follow new conference announcements

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,3 +8,7 @@ gem 'danger-commit_lint'
 gem 'html-proofer'
 gem 'jekyll'
 gem 'rake'
+
+group :jekyll_plugins do
+  gem 'jekyll-feed'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,6 +90,8 @@ GEM
       safe_yaml (~> 1.0)
       terminal-table (>= 1.8, < 4.0)
       webrick (~> 1.7)
+    jekyll-feed (0.17.0)
+      jekyll (>= 3.7, < 5.0)
     jekyll-sass-converter (3.0.0)
       sass-embedded (~> 1.54)
     jekyll-watch (2.2.1)
@@ -161,6 +163,7 @@ DEPENDENCIES
   danger-commit_lint
   html-proofer
   jekyll
+  jekyll-feed
   rake
 
 RUBY VERSION

--- a/Rakefile
+++ b/Rakefile
@@ -28,7 +28,7 @@ task :verify_data do
     "cfp_phrase",
     "cfp_date",
     "video_link",
-    "announced_at"
+    "announced_on"
   ]
   data = YAML.load File.read "_data/conferences.yml"
   validator = DataFileValidator.validate(data, allowed_keys)

--- a/Rakefile
+++ b/Rakefile
@@ -27,7 +27,8 @@ task :verify_data do
     "reg_date",
     "cfp_phrase",
     "cfp_date",
-    "video_link"
+    "video_link",
+    "announced_at"
   ]
   data = YAML.load File.read "_data/conferences.yml"
   validator = DataFileValidator.validate(data, allowed_keys)

--- a/_config.yml
+++ b/_config.yml
@@ -1,3 +1,5 @@
+name: Ruby Conferences
+url: https://rubyconferences.org
 safe: true
 lsi: false
 source: .
@@ -12,3 +14,6 @@ exclude:
   - data_file_validator.rb
   - notes.txt
   - vendor
+
+plugins:
+  - jekyll-feed

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -2656,7 +2656,7 @@
   start_date: 2024-08-24
   end_date: 2024-08-24
   url: https://regional.rubykaigi.org/osaka04/
-  announced_at: 2024-08-06
+  announced_on: 2024-08-06
 
 - name: Rails Camp USA 2024
   location: Cascade, Idaho
@@ -2664,14 +2664,14 @@
   end_date: 2024-08-30
   url: https://west.railscamp.us/2024
   twitter: railscamp_usa
-  announced_at: 2024-02-29
+  announced_on: 2024-02-29
 
 - name: Fukuoka RubyistKaigi 04
   location: Fukuoka, Japan
   start_date: 2024-09-07
   end_date: 2024-09-07
   url: https://regional.rubykaigi.org/fukuoka04/
-  announced_at: 2024-08-06
+  announced_on: 2024-08-06
 
 - name: EuRuKo 2024
   location: Sarajevo, Bosnia & Herzegovina
@@ -2683,7 +2683,7 @@
   cfp_open_date: 2024-01-12
   cfp_close_date: 2024-04-15
   cfp_link: https://www.papercall.io/euruko2024
-  announced_at: 2023-11-27
+  announced_on: 2023-11-27
 
 - name: Friendly.rb 2024
   location: Bucharest, Romania
@@ -2695,7 +2695,7 @@
   cfp_open_date: 2024-03-29
   cfp_close_date: 2024-07-01
   cfp_link: https://friendlyrb.com/cfp
-  announced_at: 2023-11-02
+  announced_on: 2023-11-02
 
 - name: Rails World 2024
   location: Toronto, Canada
@@ -2706,14 +2706,14 @@
   cfp_open_date: 2024-02-05
   cfp_close_date: 2024-03-21
   cfp_link: https://sessionize.com/rails-world/
-  announced_at: 2023-11-30
+  announced_on: 2023-11-30
 
 - name: Matsue RubyistKaigi 11
   location: Matsue, Japan
   start_date: 2024-10-05
   end_date: 2024-10-05
   url: https://matsue.rubyist.net/matrk11/
-  announced_at: 2024-08-06
+  announced_on: 2024-08-06
 
 - name: Rubyfuza 2024
   location: Cape Town, South Africa
@@ -2725,14 +2725,14 @@
   cfp_close_date: 2024-08-10
   cfp_link: https://www.papercall.io/rubyfuza-2024
   status: Canceled
-  announced_at: 2023-10-19
+  announced_on: 2023-10-19
 
 - name: Ruby Retreat 2024
   location: Warrnambool, VIC, Australia
   url: https://retreat.ruby.org.au/
   start_date: 2024-10-18
   end_date: 2024-10-21
-  announced_at: 2024-06-06
+  announced_on: 2024-06-06
 
 - name: Rocky Mountain Ruby 2024
   location: Boulder, Colorado
@@ -2744,7 +2744,7 @@
   cfp_open_date: 2024-05-15
   cfp_close_date: 2024-06-30
   cfp_link: https://sessionize.com/rocky-mountain-ruby
-  announced_at: 2024-04-17
+  announced_on: 2024-04-17
 
 - name: Haggis Ruby 2024
   location: Edinburgh, Scotland
@@ -2752,7 +2752,7 @@
   end_date: 2024-10-24
   url: https://haggisruby.co.uk
   mastodon: https://ruby.social/@haggisruby
-  announced_at: 2024-07-04
+  announced_on: 2024-07-04
 
 - name: Kaigi on Rails 2024
   location: Tokyo, Japan
@@ -2764,7 +2764,7 @@
   cfp_open_date: 2024-07-01
   cfp_close_date: 2024-07-31
   cfp_link: https://cfp.kaigionrails.org/events/2024
-  announced_at: 2024-04-15
+  announced_on: 2024-04-15
 
 - name: RubyConf 2024
   location: Chicago, IL
@@ -2776,7 +2776,7 @@
   cfp_open_date: 2024-06-06
   cfp_close_date: 2024-07-22
   cfp_link: https://sessionize.com/rubyconf-2024/
-  announced_at: 2024-01-21
+  announced_on: 2024-01-21
 
 - name: RubyConf India 2024
   location: Jaipur, India
@@ -2787,7 +2787,7 @@
   cfp_open_date: 2024-07-23
   cfp_close_date: 2024-09-25
   cfp_link: https://www.papercall.io/rubyconf-india-2024
-  announced_at: 2024-07-24
+  announced_on: 2024-07-24
 
 - name: RubyWorld Conference 2024
   location: Matsue, Japan
@@ -2795,7 +2795,7 @@
   end_date: 2024-12-06
   url: https://2024.rubyworld-conf.org/en/
   twitter: rubyworldconf
-  announced_at: 2024-05-29
+  announced_on: 2024-05-29
 
 - name: RubyKaigi 2025
   location: Matsuyama, Ehime, Japan
@@ -2804,7 +2804,7 @@
   url: https://rubykaigi.org
   twitter: rubykaigi
   mastodon: https://ruby.social/@rubykaigi
-  announced_at: 2024-05-18
+  announced_on: 2024-05-18
 
 - name: Balkan Ruby 2025
   location: Sofia, Bulgaria
@@ -2812,7 +2812,7 @@
   end_date: 2025-04-26
   url: https://balkanruby.com
   twitter: balkanruby
-  announced_at: 2024-04-28
+  announced_on: 2024-04-28
 
 - name: Helvetic Ruby 2025
   location: Geneva, Switzerland
@@ -2821,7 +2821,7 @@
   url: https://helvetic-ruby.ch
   twitter: helvetic_ruby
   mastodon: https://ruby.social/@helvetic_ruby
-  announced_at: 2024-05-17
+  announced_on: 2024-05-17
 
 - name: Brighton Ruby 2025
   location: Brighton, UK
@@ -2830,7 +2830,7 @@
   url: https://brightonruby.com
   twitter: brightonruby
   mastodon: https://ruby.social/@brightonruby
-  announced_at: 2024-06-20
+  announced_on: 2024-06-20
 
 - name: Baltic Ruby 2025
   location: Riga, Latvia
@@ -2841,7 +2841,7 @@
   url: https://balticruby.org
   twitter: balticruby
   mastodon: https://ruby.social/@balticruby
-  announced_at: 2024-06-18
+  announced_on: 2024-06-18
 
 - name: RailsConf 2025
   location: United States
@@ -2852,4 +2852,4 @@
   url: https://www.railsconf.com
   twitter: railsconf
   mastodon: https://ruby.social/@railsconf
-  announced_at: 2024-06-21
+  announced_on: 2024-06-21

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -2656,6 +2656,7 @@
   start_date: 2024-08-24
   end_date: 2024-08-24
   url: https://regional.rubykaigi.org/osaka04/
+  announced_at: 2024-01-01
 
 - name: Rails Camp USA 2024
   location: Cascade, Idaho
@@ -2663,12 +2664,14 @@
   end_date: 2024-08-30
   url: https://west.railscamp.us/2024
   twitter: railscamp_usa
+  announced_at: 2024-01-01
 
 - name: Fukuoka RubyistKaigi 04
   location: Fukuoka, Japan
   start_date: 2024-09-07
   end_date: 2024-09-07
   url: https://regional.rubykaigi.org/fukuoka04/
+  announced_at: 2024-01-01
 
 - name: EuRuKo 2024
   location: Sarajevo, Bosnia & Herzegovina
@@ -2680,6 +2683,7 @@
   cfp_open_date: 2024-01-12
   cfp_close_date: 2024-04-15
   cfp_link: https://www.papercall.io/euruko2024
+  announced_at: 2024-01-01
 
 - name: Friendly.rb 2024
   location: Bucharest, Romania
@@ -2691,6 +2695,7 @@
   cfp_open_date: 2024-03-29
   cfp_close_date: 2024-07-01
   cfp_link: https://friendlyrb.com/cfp
+  announced_at: 2024-01-01
 
 - name: Rails World 2024
   location: Toronto, Canada
@@ -2701,12 +2706,14 @@
   cfp_open_date: 2024-02-05
   cfp_close_date: 2024-03-21
   cfp_link: https://sessionize.com/rails-world/
+  announced_at: 2024-02-05
 
 - name: Matsue RubyistKaigi 11
   location: Matsue, Japan
   start_date: 2024-10-05
   end_date: 2024-10-05
   url: https://matsue.rubyist.net/matrk11/
+  announced_at: 2024-03-01
 
 - name: Rubyfuza 2024
   location: Cape Town, South Africa
@@ -2724,6 +2731,7 @@
   url: https://retreat.ruby.org.au/
   start_date: 2024-10-18
   end_date: 2024-10-21
+  announced_at: 2024-04-01
 
 - name: Rocky Mountain Ruby 2024
   location: Boulder, Colorado
@@ -2735,6 +2743,7 @@
   cfp_open_date: 2024-05-15
   cfp_close_date: 2024-06-30
   cfp_link: https://sessionize.com/rocky-mountain-ruby
+  announced_at: 2024-04-01
 
 - name: Haggis Ruby 2024
   location: Edinburgh, Scotland
@@ -2742,6 +2751,7 @@
   end_date: 2024-10-24
   url: https://haggisruby.co.uk
   mastodon: https://ruby.social/@haggisruby
+  announced_at: 2024-08-01
 
 - name: Kaigi on Rails 2024
   location: Tokyo, Japan
@@ -2753,6 +2763,7 @@
   cfp_open_date: 2024-07-01
   cfp_close_date: 2024-07-31
   cfp_link: https://cfp.kaigionrails.org/events/2024
+  announced_at: 2024-08-01
 
 - name: RubyConf 2024
   location: Chicago, IL
@@ -2764,6 +2775,7 @@
   cfp_open_date: 2024-06-06
   cfp_close_date: 2024-07-22
   cfp_link: https://sessionize.com/rubyconf-2024/
+  announced_at: 2024-01-01
 
 - name: RubyConf India 2024
   location: Jaipur, India
@@ -2774,6 +2786,7 @@
   cfp_open_date: 2024-07-23
   cfp_close_date: 2024-09-25
   cfp_link: https://www.papercall.io/rubyconf-india-2024
+  announced_at: 2024-03-01
 
 - name: RubyWorld Conference 2024
   location: Matsue, Japan
@@ -2781,6 +2794,7 @@
   end_date: 2024-12-06
   url: https://2024.rubyworld-conf.org/en/
   twitter: rubyworldconf
+  announced_at: 2024-08-01
 
 - name: RubyKaigi 2025
   location: Matsuyama, Ehime, Japan
@@ -2789,6 +2803,7 @@
   url: https://rubykaigi.org
   twitter: rubykaigi
   mastodon: https://ruby.social/@rubykaigi
+  announced_at: 2024-08-01
 
 - name: Balkan Ruby 2025
   location: Sofia, Bulgaria
@@ -2796,6 +2811,7 @@
   end_date: 2025-04-26
   url: https://balkanruby.com
   twitter: balkanruby
+  announced_at: 2024-08-01
 
 - name: Helvetic Ruby 2025
   location: Geneva, Switzerland
@@ -2804,6 +2820,7 @@
   url: https://helvetic-ruby.ch
   twitter: helvetic_ruby
   mastodon: https://ruby.social/@helvetic_ruby
+  announced_at: 2024-08-01
 
 - name: Brighton Ruby 2025
   location: Brighton, UK
@@ -2812,6 +2829,7 @@
   url: https://brightonruby.com
   twitter: brightonruby
   mastodon: https://ruby.social/@brightonruby
+  announced_at: 2024-08-01
 
 - name: Baltic Ruby 2025
   location: Riga, Latvia
@@ -2822,6 +2840,7 @@
   url: https://balticruby.org
   twitter: balticruby
   mastodon: https://ruby.social/@balticruby
+  announced_at: 2024-08-01
 
 - name: RailsConf 2025
   location: United States

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -2656,7 +2656,7 @@
   start_date: 2024-08-24
   end_date: 2024-08-24
   url: https://regional.rubykaigi.org/osaka04/
-  announced_at: 2024-01-01
+  announced_at: 2024-08-06
 
 - name: Rails Camp USA 2024
   location: Cascade, Idaho
@@ -2664,14 +2664,14 @@
   end_date: 2024-08-30
   url: https://west.railscamp.us/2024
   twitter: railscamp_usa
-  announced_at: 2024-01-01
+  announced_at: 2024-02-29
 
 - name: Fukuoka RubyistKaigi 04
   location: Fukuoka, Japan
   start_date: 2024-09-07
   end_date: 2024-09-07
   url: https://regional.rubykaigi.org/fukuoka04/
-  announced_at: 2024-01-01
+  announced_at: 2024-08-06
 
 - name: EuRuKo 2024
   location: Sarajevo, Bosnia & Herzegovina
@@ -2683,7 +2683,7 @@
   cfp_open_date: 2024-01-12
   cfp_close_date: 2024-04-15
   cfp_link: https://www.papercall.io/euruko2024
-  announced_at: 2024-01-01
+  announced_at: 2023-11-27
 
 - name: Friendly.rb 2024
   location: Bucharest, Romania
@@ -2695,7 +2695,7 @@
   cfp_open_date: 2024-03-29
   cfp_close_date: 2024-07-01
   cfp_link: https://friendlyrb.com/cfp
-  announced_at: 2024-01-01
+  announced_at: 2023-11-02
 
 - name: Rails World 2024
   location: Toronto, Canada
@@ -2706,14 +2706,14 @@
   cfp_open_date: 2024-02-05
   cfp_close_date: 2024-03-21
   cfp_link: https://sessionize.com/rails-world/
-  announced_at: 2024-02-05
+  announced_at: 2023-11-30
 
 - name: Matsue RubyistKaigi 11
   location: Matsue, Japan
   start_date: 2024-10-05
   end_date: 2024-10-05
   url: https://matsue.rubyist.net/matrk11/
-  announced_at: 2024-03-01
+  announced_at: 2024-08-06
 
 - name: Rubyfuza 2024
   location: Cape Town, South Africa
@@ -2725,13 +2725,14 @@
   cfp_close_date: 2024-08-10
   cfp_link: https://www.papercall.io/rubyfuza-2024
   status: Canceled
+  announced_at: 2023-10-19
 
 - name: Ruby Retreat 2024
   location: Warrnambool, VIC, Australia
   url: https://retreat.ruby.org.au/
   start_date: 2024-10-18
   end_date: 2024-10-21
-  announced_at: 2024-04-01
+  announced_at: 2024-06-06
 
 - name: Rocky Mountain Ruby 2024
   location: Boulder, Colorado
@@ -2743,7 +2744,7 @@
   cfp_open_date: 2024-05-15
   cfp_close_date: 2024-06-30
   cfp_link: https://sessionize.com/rocky-mountain-ruby
-  announced_at: 2024-04-01
+  announced_at: 2024-04-17
 
 - name: Haggis Ruby 2024
   location: Edinburgh, Scotland
@@ -2751,7 +2752,7 @@
   end_date: 2024-10-24
   url: https://haggisruby.co.uk
   mastodon: https://ruby.social/@haggisruby
-  announced_at: 2024-08-01
+  announced_at: 2024-07-04
 
 - name: Kaigi on Rails 2024
   location: Tokyo, Japan
@@ -2763,7 +2764,7 @@
   cfp_open_date: 2024-07-01
   cfp_close_date: 2024-07-31
   cfp_link: https://cfp.kaigionrails.org/events/2024
-  announced_at: 2024-08-01
+  announced_at: 2024-04-15
 
 - name: RubyConf 2024
   location: Chicago, IL
@@ -2775,7 +2776,7 @@
   cfp_open_date: 2024-06-06
   cfp_close_date: 2024-07-22
   cfp_link: https://sessionize.com/rubyconf-2024/
-  announced_at: 2024-01-01
+  announced_at: 2024-01-21
 
 - name: RubyConf India 2024
   location: Jaipur, India
@@ -2786,7 +2787,7 @@
   cfp_open_date: 2024-07-23
   cfp_close_date: 2024-09-25
   cfp_link: https://www.papercall.io/rubyconf-india-2024
-  announced_at: 2024-03-01
+  announced_at: 2024-07-24
 
 - name: RubyWorld Conference 2024
   location: Matsue, Japan
@@ -2794,7 +2795,7 @@
   end_date: 2024-12-06
   url: https://2024.rubyworld-conf.org/en/
   twitter: rubyworldconf
-  announced_at: 2024-08-01
+  announced_at: 2024-05-29
 
 - name: RubyKaigi 2025
   location: Matsuyama, Ehime, Japan
@@ -2803,7 +2804,7 @@
   url: https://rubykaigi.org
   twitter: rubykaigi
   mastodon: https://ruby.social/@rubykaigi
-  announced_at: 2024-08-01
+  announced_at: 2024-05-18
 
 - name: Balkan Ruby 2025
   location: Sofia, Bulgaria
@@ -2811,7 +2812,7 @@
   end_date: 2025-04-26
   url: https://balkanruby.com
   twitter: balkanruby
-  announced_at: 2024-08-01
+  announced_at: 2024-04-28
 
 - name: Helvetic Ruby 2025
   location: Geneva, Switzerland
@@ -2820,7 +2821,7 @@
   url: https://helvetic-ruby.ch
   twitter: helvetic_ruby
   mastodon: https://ruby.social/@helvetic_ruby
-  announced_at: 2024-08-01
+  announced_at: 2024-05-17
 
 - name: Brighton Ruby 2025
   location: Brighton, UK
@@ -2829,7 +2830,7 @@
   url: https://brightonruby.com
   twitter: brightonruby
   mastodon: https://ruby.social/@brightonruby
-  announced_at: 2024-08-01
+  announced_at: 2024-06-20
 
 - name: Baltic Ruby 2025
   location: Riga, Latvia
@@ -2840,7 +2841,7 @@
   url: https://balticruby.org
   twitter: balticruby
   mastodon: https://ruby.social/@balticruby
-  announced_at: 2024-08-01
+  announced_at: 2024-06-18
 
 - name: RailsConf 2025
   location: United States
@@ -2851,3 +2852,4 @@
   url: https://www.railsconf.com
   twitter: railsconf
   mastodon: https://ruby.social/@railsconf
+  announced_at: 2024-06-21

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -2650,13 +2650,14 @@
   cfp_open_date: 2024-03-15
   cfp_close_date: 2024-04-30
   cfp_link: https://cfp.madisonruby.com/events/2024/
+  announced_on: 2023-11-14
 
 - name: Osaka RubyKaigi 04
   location: Osaka, Japan
   start_date: 2024-08-24
   end_date: 2024-08-24
   url: https://regional.rubykaigi.org/osaka04/
-  announced_on: 2024-08-06
+  announced_on: 2024-03-28
 
 - name: Rails Camp USA 2024
   location: Cascade, Idaho
@@ -2671,7 +2672,7 @@
   start_date: 2024-09-07
   end_date: 2024-09-07
   url: https://regional.rubykaigi.org/fukuoka04/
-  announced_on: 2024-08-06
+  announced_on: 2023-12-14
 
 - name: EuRuKo 2024
   location: Sarajevo, Bosnia & Herzegovina
@@ -2695,7 +2696,7 @@
   cfp_open_date: 2024-03-29
   cfp_close_date: 2024-07-01
   cfp_link: https://friendlyrb.com/cfp
-  announced_on: 2023-11-02
+  announced_on: 2023-11-01
 
 - name: Rails World 2024
   location: Toronto, Canada
@@ -2713,7 +2714,7 @@
   start_date: 2024-10-05
   end_date: 2024-10-05
   url: https://matsue.rubyist.net/matrk11/
-  announced_on: 2024-08-06
+  announced_on: 2024-03-21
 
 - name: Rubyfuza 2024
   location: Cape Town, South Africa
@@ -2725,14 +2726,14 @@
   cfp_close_date: 2024-08-10
   cfp_link: https://www.papercall.io/rubyfuza-2024
   status: Canceled
-  announced_on: 2023-10-19
+  announced_on: 2023-10-18
 
 - name: Ruby Retreat 2024
   location: Warrnambool, VIC, Australia
   url: https://retreat.ruby.org.au/
   start_date: 2024-10-18
   end_date: 2024-10-21
-  announced_on: 2024-06-06
+  announced_on: 2024-04-12
 
 - name: Rocky Mountain Ruby 2024
   location: Boulder, Colorado
@@ -2764,7 +2765,7 @@
   cfp_open_date: 2024-07-01
   cfp_close_date: 2024-07-31
   cfp_link: https://cfp.kaigionrails.org/events/2024
-  announced_on: 2024-04-15
+  announced_on: 2024-02-24
 
 - name: RubyConf 2024
   location: Chicago, IL
@@ -2787,7 +2788,7 @@
   cfp_open_date: 2024-07-23
   cfp_close_date: 2024-09-25
   cfp_link: https://www.papercall.io/rubyconf-india-2024
-  announced_on: 2024-07-24
+  announced_on: 2024-07-23
 
 - name: RubyWorld Conference 2024
   location: Matsue, Japan
@@ -2830,7 +2831,7 @@
   url: https://brightonruby.com
   twitter: brightonruby
   mastodon: https://ruby.social/@brightonruby
-  announced_on: 2024-06-20
+  announced_on: 2024-06-19
 
 - name: Baltic Ruby 2025
   location: Riga, Latvia
@@ -2841,7 +2842,7 @@
   url: https://balticruby.org
   twitter: balticruby
   mastodon: https://ruby.social/@balticruby
-  announced_on: 2024-06-18
+  announced_on: 2024-06-15
 
 - name: RailsConf 2025
   location: United States
@@ -2852,4 +2853,4 @@
   url: https://www.railsconf.com
   twitter: railsconf
   mastodon: https://ruby.social/@railsconf
-  announced_on: 2024-06-21
+  announced_on: 2024-05-07

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -10,6 +10,7 @@
     <link href="//fonts.googleapis.com/css?family=Exo+2:300,400" rel="stylesheet" type="text/css">
     <link href="/css/style.css" rel="stylesheet" type="text/css">
     <link href="/images/favicon.png" rel="icon" type="image/png">
+    {% feed_meta %}
     <script src="/js/jquery.js" type="text/javascript"></script>
     <script src="/js/moment.min.js" type="text/javascript"></script>
     <script src="/js/behavior.js" type="text/javascript"></script>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -48,8 +48,7 @@
           <li><a href="https://github.com/ruby-conferences/ruby-conferences.github.io">source</a></li>
           <li><a href="https://rubyconferences.org/calendar.ics">ics events calendar feed</a></li>
           <li><a href="https://rubyconferences.org/cfp.ics">ics CFP calendar feed</a></li>
-          <li><a href="/feed.xml">RSS feed</a></li>
-        </ul>
+          <li><a href="https://rubyconferences.org/feed.xml">RSS feed</a></li>
         </ul>
       </footer>
       <script type="text/javascript">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -48,6 +48,8 @@
           <li><a href="https://github.com/ruby-conferences/ruby-conferences.github.io">source</a></li>
           <li><a href="https://rubyconferences.org/calendar.ics">ics events calendar feed</a></li>
           <li><a href="https://rubyconferences.org/cfp.ics">ics CFP calendar feed</a></li>
+          <li><a href="/feed.xml">RSS feed</a></li>
+        </ul>
         </ul>
       </footer>
       <script type="text/javascript">

--- a/feed.xml
+++ b/feed.xml
@@ -8,11 +8,11 @@
   <updated>{{ site.time | date_to_xmlschema }}</updated>
   <id>{{ site.url }}/feed.xml</id>
 
-  {% assign latest_events = site.data.conferences | reverse | slice: 0, 30 %}
+  {% assign latest_events = site.data.conferences | reverse | slice: 0, 50 %}
   {% for event in latest_events %}
-    {% if event.announced_at %}
+    {% if event.announced_on %}
       <entry>
-        <published>{{ event.announced_at | date: "%Y-%m-%dT%H:%M:%S%z" }}</published>
+        <published>{{ event.announced_on | date: "%Y-%m-%dT%H:%M:%S%z" }}</published>
 
         <title>{{ event.name }}</title>
         <id>{{ event.url }}</id>

--- a/feed.xml
+++ b/feed.xml
@@ -1,0 +1,28 @@
+---
+---
+<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title type="text" xml:lang="en">{{ site.name }}</title>
+  <link type="application/atom+xml" href="atom_feed_url" rel="self"/>
+  <link type="text/html" href="home_url_canonical" rel="alternate"/>
+  <updated>{{ site.time | date_to_xmlschema }}</updated>
+  <id>{{ site.url }}/feed.xml</id>
+
+  {% assign latest_events = site.data.conferences | reverse | slice: 0, 30 %}
+  {% for event in latest_events %}
+    {% if event.announced_at %}
+      <entry>
+        <published>{{ event.announced_at | date: "%Y-%m-%dT%H:%M:%S%z" }}</published>
+
+        <title>{{ event.name }}</title>
+        <id>{{ event.url }}</id>
+        <link href="{{ event.url }}" />
+        <content type="html">
+          <![CDATA[
+          {% include event.html %}
+          ]]>
+        </content>
+      </entry>
+    {% endif %}
+  {% endfor %}
+</feed>


### PR DESCRIPTION
A revision of previously closed PR https://github.com/ruby-conferences/ruby-conferences.github.io/pull/339

Resolves https://github.com/ruby-conferences/ruby-conferences.github.io/issues/226

---

Atom/RSS is an excellent way to follow updates to websites. Ruby Conferences is an excellent site but it's currently difficult to know when new conferences are added. This PR introduces an Atom feed to make tracking new conference announcements easier. 

Notes:

* Uses the [Jekyll feed](https://github.com/jekyll/jekyll-feed) plugin
* Adds a new `announced_on` field to `conferences.yml` to track the announcement date
* If an entry has no `announced_on`, it's ignored
* The feed is accessed at `/feed.xml`