### PR TITLE
Automate fetching Meetups from Meetup.com

### DIFF
--- a/.github/workflows/meetups.yml
+++ b/.github/workflows/meetups.yml
@@ -1,0 +1,99 @@
+name: Fetch Meetups
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *" # Runs every day at 00:00 UTC time
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  fetch:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Ruby
+
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: Check for new Meetups
+        run: bundle exec rake fetch_meetups
+
+      - name: Verify Meetups Data
+        run: bundle exec rake verify_meetups
+
+      - name: Set up the formatted date and branch name
+        run: |
+          echo "FORMATTED_DATE=$(date +'%B %d, %Y')" >> $GITHUB_ENV
+          echo "BRANCH_TO_MERGE=new-meetups-$(date +'%Y-%m-%d')" >> $GITHUB_ENV
+
+      - name: Commit New Meetups
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          # Optional. Commit message for the created commit.
+          # Defaults to "Apply automatic changes"
+          commit_message: New Meetups on ${{ env.FORMATTED_DATE }}
+
+          # Optional. Local and remote branch name where commit is going to be pushed
+          #  to. Defaults to the current branch.
+          #  You might need to set `create_branch: true` if the branch does not exist.
+          branch: ${{ env.BRANCH_TO_MERGE }}
+
+          # Optional. Options used by `git-commit`.
+          # See https://git-scm.com/docs/git-commit#_options
+          # commit_options: '--no-verify --signoff'
+
+          # Optional glob pattern of files which should be added to the commit
+          # Defaults to all (.)
+          # See the `pathspec`-documentation for git
+          # - https://git-scm.com/docs/git-add#Documentation/git-add.txt-ltpathspecgt82308203
+          # - https://git-scm.com/docs/gitglossary#Documentation/gitglossary.txt-aiddefpathspecapathspec
+          file_pattern: '_data/*.yml'
+
+          # Optional. Local file path to the repository.
+          # Defaults to the root of the repository.
+          # repository: .
+
+          # Optional commit user and author settings
+          # commit_user_name: My GitHub Actions Bot # defaults to "github-actions[bot]"
+          # commit_user_email: my-github-actions-bot@example.org # defaults to "41898282+github-actions[bot]@users.noreply.github.com"
+          # commit_author: Author <actions@github.com> # defaults to "username <username@users.noreply.github.com>", where "username" belongs to the author of the commit that triggered the run
+
+          # Optional. Tag name being created in the local repository and
+          # pushed to remote repository and defined branch.
+          # tagging_message: 'v1.0.0'
+
+          # Optional. Option used by `git-status` to determine if the repository is
+          # dirty. See https://git-scm.com/docs/git-status#_options
+          status_options: '--untracked-files=no'
+
+          # Optional. Options used by `git-add`.
+          # See https://git-scm.com/docs/git-add#_options
+          # add_options: '-u'
+
+          # Optional. Options used by `git-push`.
+          # See https://git-scm.com/docs/git-push#_options
+          # push_options: '--force'
+
+          # Optional. Disable dirty check and always try to create a commit and push
+          # skip_dirty_check: true
+
+          # Optional. Skip internal call to `git fetch`
+          # skip_fetch: true
+
+          # Optional. Skip internal call to `git checkout`
+          # skip_checkout: true
+
+          # Optional. Prevents the shell from expanding filenames.
+          # Details: https://www.gnu.org/software/bash/manual/html_node/Filename-Expansion.html
+          # disable_globbing: true
+
+          # Optional. Create given branch name in local and remote repository.
+          create_branch: true
+
+      - name: Create Pull Request
+        run: gh pr create -B main -H ${{ env.BRANCH_TO_MERGE }} --title "New Meetups on ${{ env.FORMATTED_DATE }}" --body "Newly added Meetups on ${{ env.FORMATTED_DATE }}."

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,9 @@ gem 'danger-commit_lint'
 gem 'html-proofer'
 gem 'jekyll'
 gem 'rake'
+gem 'graphql-client', '~> 0.23.0'
+gem 'frozen_record', '~> 0.27.2'
+gem 'countries', '~> 6.0'
 
 group :jekyll_plugins do
   gem 'jekyll-feed'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,19 @@ GEM
   remote: https://rubygems.org/
   specs:
     Ascii85 (1.1.0)
+    activemodel (7.2.1)
+      activesupport (= 7.2.1)
+    activesupport (7.2.1)
+      base64
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.3.1)
+      connection_pool (>= 2.2.5)
+      drb
+      i18n (>= 1.6, < 2)
+      logger (>= 1.4.2)
+      minitest (>= 5.1)
+      securerandom (>= 0.3)
+      tzinfo (~> 2.0, >= 2.0.5)
     addressable (2.8.6)
       public_suffix (>= 2.0.2, < 6.0)
     afm (0.2.2)
@@ -9,6 +22,7 @@ GEM
       console (~> 1.10)
       io-event (~> 1.1)
       timers (~> 4.1)
+    base64 (0.2.0)
     bigdecimal (3.1.8)
     claide (1.1.0)
     claide-plugins (0.9.2)
@@ -18,10 +32,13 @@ GEM
     colorator (1.1.0)
     colored2 (3.1.2)
     concurrent-ruby (1.3.3)
+    connection_pool (2.4.1)
     console (1.16.2)
       fiber-local
     cork (0.3.0)
       colored2 (~> 3.1)
+    countries (6.0.1)
+      unaccent (~> 0.3)
     danger (9.2.0)
       claide (~> 1.0)
       claide-plugins (>= 0.9.2)
@@ -39,6 +56,7 @@ GEM
       danger-plugin-api (~> 1.0)
     danger-plugin-api (1.0.0)
       danger (> 2.0)
+    drb (2.2.1)
     em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
@@ -53,13 +71,22 @@ GEM
     faraday-net_http (3.0.2)
     ffi (1.17.0)
     fiber-local (1.0.0)
+    fiber-storage (1.0.0)
     forwardable-extended (2.6.0)
+    frozen_record (0.27.2)
+      activemodel
     git (1.13.2)
       addressable (~> 2.8)
       rchardet (~> 1.8)
     google-protobuf (4.27.1)
       bigdecimal
       rake (>= 13)
+    graphql (2.3.14)
+      base64
+      fiber-storage
+    graphql-client (0.23.0)
+      activesupport (>= 3.0)
+      graphql (>= 1.13.0)
     hashery (2.1.2)
     html-proofer (5.0.4)
       addressable (~> 2.3)
@@ -104,8 +131,10 @@ GEM
     listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
+    logger (1.6.0)
     mercenary (0.4.0)
     mini_portile2 (2.8.6)
+    minitest (5.25.1)
     nap (1.1.0)
     no_proxy_fix (0.1.2)
     nokogiri (1.16.5)
@@ -143,6 +172,7 @@ GEM
     sawyer (0.9.2)
       addressable (>= 2.3.5)
       faraday (>= 0.17.3, < 3)
+    securerandom (0.3.1)
     strscan (3.1.0)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
@@ -150,6 +180,9 @@ GEM
     ttfunk (1.7.0)
     typhoeus (1.4.0)
       ethon (>= 0.9.0)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
+    unaccent (0.4.0)
     unicode-display_width (2.5.0)
     webrick (1.8.1)
     yell (2.2.2)
@@ -159,8 +192,11 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  countries (~> 6.0)
   danger
   danger-commit_lint
+  frozen_record (~> 0.27.2)
+  graphql-client (~> 0.23.0)
   html-proofer
   jekyll
   jekyll-feed

--- a/Rakefile
+++ b/Rakefile
@@ -2,6 +2,7 @@
 require 'yaml'
 require 'date'
 require './data_file_validator'
+require './meetup_client'
 
 desc "Build Jekyll site"
 task :build do
@@ -65,6 +66,18 @@ task :verify_meetups do
   events = validator.events
   dates = events.map { |event| event["start_date"] }
   exit 5 unless dates.sort == dates
+end
+
+task :fetch_meetups do
+  MeetupGroup.all.each do |group|
+    group.write_new_meetups!
+  end
+
+  events = YAML.load_file("./_data/meetups.yml", permitted_classes: [Date])
+
+  events.sort_by! { |event| [event["date"], event["name"]] }
+
+  File.write("./_data/meetups.yml", events.to_yaml.gsub("- name:", "\n- name:"))
 end
 
 task default: [:build, :verify_data, :verify_html]

--- a/_data/meetup_groups.yml
+++ b/_data/meetup_groups.yml
@@ -1,0 +1,122 @@
+- id: austinrb
+  name: AustinRB
+  service: meetupdotcom
+
+- id: barcelona-rb
+  name: Barcelona.rb
+  service: meetupdotcom
+
+# - id: bostonrb
+#   name: Boston Ruby Group
+#   service: meetupdotcom
+
+- id: bostonrb
+  name: Boston Ruby Group
+  service: luma
+  ical_url: https://api.lu.ma/ics/get?entity=calendar&id=cal-O0xLKEqq4Q8vc8f
+
+- id: boulder-ruby
+  name: Boulder Ruby
+  service: luma
+  ical_url: https://api.lu.ma/ics/get?entity=calendar&id=cal-B9LZxdgJiXBxezw
+
+- id: brooklyn-rb
+  name: brooklyn.rb
+  service: meetupdotcom
+
+- id: charlotte-rb
+  name: Charlotte Ruby Meetup Group
+  service: meetupdotcom
+
+- id: chicagoruby
+  name: ChicagoRuby
+  service: meetupdotcom
+
+- id: copenhagen-ruby-brigade
+  name: Copenhagen Ruby Brigade
+  service: meetupdotcom
+
+- id: frankfurt-ruby-meetup
+  name: Frankfurt Ruby Meetup
+  service: meetupdotcom
+
+- id: geneva-rb
+  name: Geneva.rb
+  service: meetupdotcom
+
+- id: houstonruby
+  name: Houston Ruby
+  service: meetupdotcom
+
+- id: krakow-ruby-users-group
+  name: Krakow Ruby Users Group (KRUG)
+  service: meetupdotcom
+
+- id: laruby
+  name: LA Ruby - The Los Angeles Ruby Meetup Group
+  service: meetupdotcom
+
+- id: lyonrb
+  name: Lyon.rb
+  service: meetupdotcom
+
+- id: nyc-rb
+  name: NYC.rb
+  service: meetupdotcom
+
+- id: paris_rb
+  name: ParisRB.new
+  service: meetupdotcom
+
+- id: phillyrb
+  name: Philly.rb
+  service: meetupdotcom
+
+- id: polishrubyusergroup
+  name: Polish Ruby User Group
+  service: meetupdotcom
+
+- id: ruby-az
+  name: Ruby::AZ
+  service: meetupdotcom
+
+- id: ruby-in-london
+  name: Ruby in London
+  service: meetupdotcom
+
+- id: ruby-montevideo
+  name: Ruby Montevideo
+  service: meetupdotcom
+
+- id: ruby-phil
+  name: Philippine Ruby Users Group
+  service: meetupdotcom
+
+- id: ruby-romania
+  name: Ruby Romania
+  service: meetupdotcom
+
+- id: rubyba
+  name: Ruby Buenos Aires
+  service: meetupdotcom
+
+- id: rubyonrails-ch
+  name: Ruby on Rails Schweiz
+  service: meetupdotcom
+
+# - id: TODO
+#   name: SF
+#   service: luma
+
+- id: sdruby
+  name: SD Ruby
+  service: meetupdotcom
+
+- id: the-bluegrass-developers-guild
+  name: Bluegrass Ruby Users Group
+  filter: Bluegrass Ruby
+  service: meetupdotcom
+
+- id: upstate-ruby
+  name: Upstate Ruby
+  service: meetupdotcom

--- a/_data/meetups.yml
+++ b/_data/meetups.yml
@@ -1217,7 +1217,7 @@
   date: 2024-08-13
   start_time: 20:30:00 EDT
   end_time: 22:00:00 EDT
-  url: https://www.meetup.com/phillyrb/events/nnlgbtygclbrb
+  url: https://www.meetup.com/phillyrb/events/302705860
 
 - name: Ruby Montevideo - Meetup August 2024
   location: Montevideo, Uruguay
@@ -1244,8 +1244,8 @@
   location: Boulder, CO / Online
   date: 2024-08-14
   start_time: 18:00:00 MDT
-  end_time: 21:00:00 MDT
-  url: https://www.meetup.com/boulder_ruby_group/events/bbsqktygclbsb
+  end_time: 20:30:00 MDT
+  url: https://lu.ma/16ykggyu
 
 - name: RubySur - August 2024 - Refactoring
   location: Buenos Aires, Argentina / Online
@@ -1289,13 +1289,6 @@
   end_time: 20:00:00 PHT
   url: https://www.meetup.com/ruby-phil/events/302886229
 
-- name: Boston Ruby Group - Project Night
-  location: Boston, MA
-  date: 2024-09-02
-  start_time: 18:00:00 EDT
-  end_time: 20:00:00 EDT
-  url: https://www.meetup.com/bostonrb/events/301905492
-
 - name: Bluegrass Ruby Users Group - September 2024
   location: Lexington, KY
   date: 2024-09-03
@@ -1324,12 +1317,19 @@
   end_time: 21:00:00 PDT
   url: https://www.meetup.com/sdruby/events/hjmpmtygcmbhb
 
+- name: Boston Ruby Group - Project Night
+  location: Boston, MA
+  date: 2024-09-09
+  start_time: 18:00:00 EDT
+  end_time: 20:00:00 EDT
+  url: https://lu.ma/af2n3jwa
+
 - name: Boulder Ruby Group - Monthly Presentation Night
   location: Boulder, CO / Online
   date: 2024-09-11
   start_time: 18:00:00 MDT
-  end_time: 21:00:00 MDT
-  url: https://www.meetup.com/boulder_ruby_group/events/bbsqktygcmbpb
+  end_time: 20:30:00 MDT
+  url: https://lu.ma/yithw455
 
 - name: NYC.rb - Dennis Martinez on Kamal
   location: Online
@@ -1343,7 +1343,7 @@
   date: 2024-09-11
   start_time: 20:30:00 EDT
   end_time: 22:00:00 EDT
-  url: https://www.meetup.com/phillyrb/events/nnlgbtygcmbnb
+  url: https://www.meetup.com/phillyrb/events/302815061
 
 - name: 'Krakow Ruby Users Group - KRUG #2 2024'
   location: Krakow, Poland
@@ -1352,12 +1352,19 @@
   end_time: 21:00:00 CEST
   url: https://www.meetup.com/krakow-ruby-users-group/events/302822679
 
-- name: 'Ruby Frankfurt Meetup - September 2024'
+- name: Ruby Frankfurt Meetup - September 2024
   location: Frankfurt, Germany
   date: 2024-09-17
   start_time: 19:00:00 CEST
   end_time: 21:00:00 CEST
   url: https://www.meetup.com/frankfurt-ruby-meetup/events/302960601
+
+- name: Boston Ruby Group - September 2024 meeting
+  location: Boston, MA
+  date: 2024-09-17
+  start_time: 18:00:00 EDT
+  end_time: 20:00:00 EDT
+  url: https://lu.ma/sbesulha
 
 - name: Bluegrass Ruby Users Group - October 2024
   location: Lexington, KY
@@ -1378,21 +1385,21 @@
   date: 2024-10-03
   start_time: 19:00:00 PDT
   end_time: 21:00:00 PDT
-  url: https://www.meetup.com/sdruby/events/hjmpmtygcnbfb
+  url: https://www.meetup.com/sdruby/events/302800231
 
 - name: Boston Ruby Group - Project Night
   location: Boston, MA
   date: 2024-10-07
   start_time: 18:00:00 EDT
   end_time: 20:00:00 EDT
-  url: https://www.meetup.com/bostonrb/events/zxzdmtygcnbkb
+  url: https://lu.ma/5wyckv9i
 
 - name: Philly.rb - Pubnite October 2024
   location: Online
   date: 2024-10-08
   start_time: 20:30:00 EDT
   end_time: 22:00:00 EDT
-  url: https://www.meetup.com/phillyrb/events/nnlgbtygcnblb
+  url: https://www.meetup.com/phillyrb/events/302834153
 
 - name: Ruby AI Happy Hour & Demo Night
   location: New York, NY
@@ -1405,8 +1412,8 @@
   location: Boulder, CO / Online
   date: 2024-10-09
   start_time: 18:00:00 MDT
-  end_time: 21:00:00 MDT
-  url: https://www.meetup.com/boulder_ruby_group/events/bbsqktygcnbmb
+  end_time: 20:30:00 MDT
+  url: https://lu.ma/57vrruyr
 
 - name: NYC.rb - October 2024
   location: Online
@@ -1420,7 +1427,7 @@
   date: 2024-11-04
   start_time: 18:00:00 EST
   end_time: 20:00:00 EST
-  url: https://www.meetup.com/bostonrb/events/zxzdmtygcpbgb
+  url: https://lu.ma/zs5he82r
 
 - name: Bluegrass Ruby Users Group - November 2024
   location: Lexington, KY
@@ -1449,6 +1456,13 @@
   start_time: 20:30:00 EST
   end_time: 22:00:00 EST
   url: https://www.meetup.com/phillyrb/events/nnlgbtygcpbqb
+
+- name: Boulder Ruby Group - Monthly Presentation Night
+  location: Boulder, CO / Online
+  date: 2024-11-13
+  start_time: 18:00:00 MST
+  end_time: 20:30:00 MST
+  url: https://lu.ma/y1c2jita
 
 - name: NYC.rb - November 2024
   location: Online

--- a/meetup_client.rb
+++ b/meetup_client.rb
@@ -94,17 +94,18 @@ class MeetupGroup < FrozenRecord::Base
       upcoming_events
     end
 
-    group = @upcoming_events_result.dig("data", "groupByUrlname")
+    group = @upcoming_events_result.original_hash.dig("data", "groupByUrlname")
 
     city = group.dig("city")
     state = group.dig("state")
     country = group.dig("country")
 
-    if country == "us"
+    country = ISO3166::Country.new(country)
+
+    if country.alpha2 == "US"
       "#{city}, #{state.upcase}"
     else
-      country = ISO3166::Country.new(country)
-      "#{city}, #{country&.iso_long_name}"
+      "#{city}, #{country&.iso_short_name}"
     end
   end
 
@@ -145,13 +146,14 @@ class MeetupGroup < FrozenRecord::Base
     state = event.venue.dig("state")
     country = event.venue.dig("country")
 
+    country = ISO3166::Country.new(country)
+
     if event.isOnline
       meetup_location = "Online"
-    elsif country == "us"
+    elsif country.alpha2 == "US"
       meetup_location = "#{city}, #{state.upcase}"
-    elsif country && country != "us"
-      country = ISO3166::Country.new(country)
-      meetup_location = "#{city}, #{country&.iso_long_name}"
+    elsif country
+      meetup_location = "#{city}, #{country&.iso_short_name}"
     else
       meetup_location = location
     end

--- a/meetup_client.rb
+++ b/meetup_client.rb
@@ -1,0 +1,186 @@
+require "yaml"
+require "pathname"
+require "ostruct"
+
+require "tzinfo"
+require "countries"
+require "frozen_record"
+
+require "graphql/client"
+require "graphql/client/http"
+
+module MeetupClient
+  BASE = "https://api.meetup.com/gql".freeze
+  HTTP = GraphQL::Client::HTTP.new(BASE) do
+    def headers(context)
+      {
+        Authorization: "Bearer #{ENV["MEETUP_API_TOKEN"]}",
+        "Content-Type": "application/json",
+      }
+    end
+  end
+
+  Schema = GraphQL::Client.load_schema("./meetup_graphql_schema.json")
+  Client = GraphQL::Client.new(schema: Schema, execute: HTTP)
+end
+
+EventsQuery = MeetupClient::Client.parse(<<-GRAPHQL
+  query ($groupId: String!) {
+    groupByUrlname(urlname: $groupId) {
+      id
+      logo {
+        id
+        baseUrl
+        preview
+        source
+      }
+      name
+      country
+      state
+      city
+      unifiedEvents(sortOrder: ASC) {
+        count
+        edges {
+          cursor
+          node {
+            id
+            title
+            eventUrl
+            shortDescription
+            description
+            onlineVenue {
+              type
+              url
+            }
+            venue {
+              address
+              city
+              state
+              country
+            }
+            host {
+              id
+              name
+              email
+            }
+            status
+            dateTime
+            endTime
+            duration
+            timezone
+            createdAt
+            eventType
+            isOnline
+          }
+        }
+      }
+    }
+  }
+  GRAPHQL
+)
+
+FrozenRecord::Base.auto_reloading = true
+FrozenRecord::Base.base_path = "./_data"
+
+class Conference < FrozenRecord::Base
+end
+
+class MeetupGroup < FrozenRecord::Base
+  scope :meetupdotcom, -> { where(service: "meetupdotcom" ) }
+  scope :luma, -> { where(service: "luma" ) }
+
+  def location
+    unless @upcoming_events_result
+      upcoming_events
+    end
+
+    group = @upcoming_events_result.dig("data", "groupByUrlname")
+
+    city = group.dig("city")
+    state = group.dig("state")
+    country = group.dig("country")
+
+    if country == "us"
+      "#{city}, #{state.upcase}"
+    else
+      country = ISO3166::Country.new(country)
+      "#{city}, #{country&.iso_long_name}"
+    end
+  end
+
+  def upcoming_events
+    result = MeetupClient::Client.query(EventsQuery, variables: { groupId: id })
+
+    @upcoming_events_result = result
+
+    events = Array(result.original_hash.dig("data", "groupByUrlname", "unifiedEvents", "edges"))
+    events = events.map { |event| OpenStruct.new(event["node"]) }
+
+    if filter.present?
+      events = events.select! { |event| event.title.include?(filter) }
+    end
+
+    events
+  end
+
+  def new_events
+    upcoming = upcoming_events
+    upcoming_ids = upcoming.map(&:id)
+
+    new_event_ids = upcoming_ids - existing_event_ids
+
+    new_event_ids.map { |new_id| upcoming.find { |upcoming| new_id == upcoming.id } }
+  end
+
+  def existing_events
+    Meetup.all.select { |meetup| meetup.url.include?(id) }
+  end
+
+  def existing_event_ids
+    existing_events.map(&:service_id)
+  end
+
+  def openstruct_to_yaml(event)
+    city = event.venue.dig("city")
+    state = event.venue.dig("state")
+    country = event.venue.dig("country")
+
+    if event.isOnline
+      meetup_location = "Online"
+    elsif country == "us"
+      meetup_location = "#{city}, #{state.upcase}"
+    elsif country && country != "us"
+      country = ISO3166::Country.new(country)
+      meetup_location = "#{city}, #{country&.iso_long_name}"
+    else
+      meetup_location = location
+    end
+
+    timezone = TZInfo::Timezone.get(event.timezone).now.strftime("%Z")
+
+    <<~YAML
+      - name: "#{name} - #{event.title.gsub(name, "").squeeze(" ").strip}"
+        location: "#{meetup_location}"
+        date: #{Date.parse(event.dateTime).iso8601}
+        start_time: "#{Time.parse(event.dateTime).strftime("%H:%M:%S")} #{timezone}"
+        end_time: "#{Time.parse(event.endTime).strftime("%H:%M:%S")} #{timezone}"
+        url: "#{event.eventUrl}"
+    YAML
+  end
+
+  def write_new_meetups!
+    new_events.each do |event|
+      next unless Date.parse(event.dateTime).between?(Date.today - 1, Date.today + 90)
+
+      File.write("./_data/meetups.yml", openstruct_to_yaml(event), mode: "a+")
+    end
+  end
+end
+
+class Meetup < FrozenRecord::Base
+  def service_id
+    if url.start_with?("https://www.meetup.com/") || url.start_with?("https://meetup.com/")
+      url.split("/").last
+    end
+  end
+end

--- a/meetup_graphql_schema.json
+++ b/meetup_graphql_schema.json
@@ -1,0 +1,427 @@
+{
+  "data": {
+    "__schema": {
+      "queryType": {
+        "name": "Query"
+      },
+      "types": [
+        {
+          "kind": "OBJECT",
+          "name": "Query",
+          "fields": [
+            {
+              "name": "groupByUrlname",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Group"
+              },
+              "args": [
+                {
+                  "name": "urlname",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String"
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Group",
+          "fields": [
+            {
+              "name": "id",
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID"
+              },
+              "args": []
+            },
+            {
+              "name": "logo",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Logo"
+              },
+              "args": []
+            },
+            {
+              "name": "name",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String"
+              },
+              "args": []
+            },
+            {
+              "name": "country",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String"
+              },
+              "args": []
+            },
+            {
+              "name": "state",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String"
+              },
+              "args": []
+            },
+            {
+              "name": "city",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String"
+              },
+              "args": []
+            },
+            {
+              "name": "unifiedEvents",
+              "type": {
+                "kind": "OBJECT",
+                "name": "EventConnection"
+              },
+              "args": [
+                {
+                  "name": "sortOrder",
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "SortOrder"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Logo",
+          "fields": [
+            {
+              "name": "id",
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID"
+              },
+              "args": []
+            },
+            {
+              "name": "baseUrl",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String"
+              },
+              "args": []
+            },
+            {
+              "name": "preview",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String"
+              },
+              "args": []
+            },
+            {
+              "name": "source",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String"
+              },
+              "args": []
+            }
+          ]
+        },
+        {
+          "kind": "OBJECT",
+          "name": "EventConnection",
+          "fields": [
+            {
+              "name": "count",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int"
+              },
+              "args": []
+            },
+            {
+              "name": "edges",
+              "type": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "EventEdge"
+                }
+              },
+              "args": []
+            }
+          ]
+        },
+        {
+          "kind": "OBJECT",
+          "name": "EventEdge",
+          "fields": [
+            {
+              "name": "cursor",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String"
+              },
+              "args": []
+            },
+            {
+              "name": "node",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Event"
+              },
+              "args": []
+            }
+          ]
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Event",
+          "fields": [
+            {
+              "name": "id",
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID"
+              },
+              "args": []
+            },
+            {
+              "name": "title",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String"
+              },
+              "args": []
+            },
+            {
+              "name": "eventUrl",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String"
+              },
+              "args": []
+            },
+            {
+              "name": "shortDescription",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String"
+              },
+              "args": []
+            },
+            {
+              "name": "description",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String"
+              },
+              "args": []
+            },
+            {
+              "name": "onlineVenue",
+              "type": {
+                "kind": "OBJECT",
+                "name": "OnlineVenue"
+              },
+              "args": []
+            },
+            {
+              "name": "venue",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Venue"
+              },
+              "args": []
+            },
+            {
+              "name": "host",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Host"
+              },
+              "args": []
+            },
+            {
+              "name": "status",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String"
+              },
+              "args": []
+            },
+            {
+              "name": "dateTime",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String"
+              },
+              "args": []
+            },
+            {
+              "name": "endTime",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String"
+              },
+              "args": []
+            },
+            {
+              "name": "duration",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int"
+              },
+              "args": []
+            },
+            {
+              "name": "timezone",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String"
+              },
+              "args": []
+            },
+            {
+              "name": "createdAt",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String"
+              },
+              "args": []
+            },
+            {
+              "name": "eventType",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String"
+              },
+              "args": []
+            },
+            {
+              "name": "isOnline",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean"
+              },
+              "args": []
+            }
+          ]
+        },
+        {
+          "kind": "OBJECT",
+          "name": "OnlineVenue",
+          "fields": [
+            {
+              "name": "type",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String"
+              },
+              "args": []
+            },
+            {
+              "name": "url",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String"
+              },
+              "args": []
+            }
+          ]
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Venue",
+          "fields": [
+            {
+              "name": "address",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String"
+              },
+              "args": []
+            },
+            {
+              "name": "city",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String"
+              },
+              "args": []
+            },
+            {
+              "name": "state",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String"
+              },
+              "args": []
+            },
+            {
+              "name": "country",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String"
+              },
+              "args": []
+            }
+          ]
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Host",
+          "fields": [
+            {
+              "name": "id",
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID"
+              },
+              "args": []
+            },
+            {
+              "name": "name",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String"
+              },
+              "args": []
+            },
+            {
+              "name": "email",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String"
+              },
+              "args": []
+            }
+          ]
+        },
+        {
+          "kind": "ENUM",
+          "name": "SortOrder",
+          "enumValues": [
+            {
+              "name": "ASC"
+            },
+            {
+              "name": "DESC"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
This pull request adds a GitHub Action to automate the fetching for newly created meetups on Meetup.com. It runs at midnight UTC everyday.

We also only add meetups within the next three months so are not polluting the list too much. But maybe we just need a better design/view which can handle this big list of meetups. Maybe even split up the list by month/country/continent?

Here's an example PR of what this workflow does: https://github.com/marcoroth/ruby-conferences.github.io/pull/1

Partially solves #711.