### PR TITLE
Automate fetching meetups from Luma/ical

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem 'rake'
 gem 'graphql-client', '~> 0.23.0'
 gem 'frozen_record', '~> 0.27.2'
 gem 'countries', '~> 6.0'
+gem 'icalendar', '~> 2.10'
 
 group :jekyll_plugins do
   gem 'jekyll-feed'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,6 +66,9 @@ GEM
     http_parser.rb (0.8.0)
     i18n (1.14.5)
       concurrent-ruby (~> 1.0)
+    icalendar (2.10.2)
+      ice_cube (~> 0.16)
+    ice_cube (0.17.0)
     io-event (1.1.6)
     jekyll (4.3.3)
       addressable (~> 2.4)
@@ -151,6 +154,7 @@ DEPENDENCIES
   frozen_record (~> 0.27.2)
   graphql-client (~> 0.23.0)
   html-proofer
+  icalendar (~> 2.10)
   jekyll
   jekyll-feed
   rake

--- a/_data/meetup_groups.yml
+++ b/_data/meetup_groups.yml
@@ -324,6 +324,12 @@
   name: Lyon.rb
   service: meetupdotcom
 
+- id: madison-ruby
+  name: Madison+ Ruby
+  service: luma
+  ical_url: https://api.lu.ma/ics/get?entity=calendar&id=cal-LlD9HPh8QnHgqEQ
+  timezone: America/Chicago
+
 - id: medellin-rb
   name: Medellín.rb
   service: meetupdotcom

--- a/_data/meetup_groups.yml
+++ b/_data/meetup_groups.yml
@@ -95,6 +95,7 @@
   name: Boston Ruby Group
   service: luma
   ical_url: https://api.lu.ma/ics/get?entity=calendar&id=cal-O0xLKEqq4Q8vc8f
+  timezone: America/New_York
 
 # - id: boulder-denver-railsbridge
 #   name:
@@ -104,6 +105,7 @@
   name: Boulder Ruby
   service: luma
   ical_url: https://api.lu.ma/ics/get?entity=calendar&id=cal-B9LZxdgJiXBxezw
+  timezone: America/Denver
 
 - id: boulder_ruby_group
   name: Boulder Ruby Group
@@ -556,6 +558,12 @@
 #   name:
 #   service: meetupdotcom
 
+- id: ruby-fusion
+  name: Ruby Fusion
+  service: luma
+  ical_url: https://api.lu.ma/ics/get?entity=calendar&id=cal-HxTn4dLUlMlzEQX
+  timezone: America/Denver
+
 - id: ruby-in-london
   name: Ruby in London
   service: meetupdotcom
@@ -810,6 +818,7 @@
   name: SF Bay Area Ruby
   service: luma
   ical_url: https://api.lu.ma/ics/get?entity=calendar&id=cal-L4SDawu65B1grBV
+  timezone: America/Los_Angeles
 
 - id: silicon-valley-ruby
   name: Silicon Valley Ruby

--- a/_data/meetups.yml
+++ b/_data/meetups.yml
@@ -393,7 +393,7 @@
   end_time: 20:00:00 MST
   url: https://www.meetup.com/ruby-az/events/299773440
 
-- name: SF Bay Area Ruby Meetup @ GitHub HQ
+- name: SF Bay Area Ruby - Meetup
   location: San Francisco, CA
   date: 2024-03-28
   start_time: 17:00:00 PDT
@@ -603,12 +603,12 @@
   end_time: 20:00:00 HKT
   url: https://www.facebook.com/events/758719776072660/
 
-- name: Ruby Fusion - May 2024
+- name: Ruby Fusion - Meetup May 2024
   location: Online
   date: 2024-05-09
-  start_time: 21:00:00 EDT
-  end_time: 22:30:00 EDT
-  url: https://lu.ma/ruby_fusion
+  start_time: 19:00:00 MDT
+  end_time: 20:30:00 MDT
+  url: https://lu.ma/ruby_fusion-inception
 
 - name: Ruby Montevideo - Meetup May 2024
   location: Montevideo, Uruguay
@@ -673,7 +673,7 @@
   end_time: 21:00:00 MDT
   url: https://www.meetup.com/boulder_ruby_group/events/299093266
 
-- name: SF Bay Area Ruby Meetup @ New Relic
+- name: SF Bay Area Ruby - Meetup @ New Relic
   location: San Francisco, CA
   date: 2024-05-16
   start_time: 17:00:00 PDT
@@ -820,11 +820,11 @@
   end_time: 20:30:00 CEST
   url: https://www.meetup.com/geneva-rb/events/299288852
 
-- name: Ruby Fusion - June 2024 - Function Composition
+- name: Ruby Fusion - Function Composition
   location: Online
   date: 2024-06-06
-  start_time: 18:30:00 EDT
-  end_time: 20:30:00 EDT
+  start_time: 18:30:00 MDT
+  end_time: 20:30:00 MDT
   url: https://lu.ma/ruby_fusion
 
 - name: Ruby Montevideo - Meetup June 2024
@@ -911,7 +911,7 @@
   end_time: 20:30:00 ART
   url: https://www.meetup.com/rubyba/events/301367143
 
-- name: SF Bay Area Ruby Meetup @ ProductBoard
+- name: SF Bay Area Ruby - Meetup in June @ Productboard
   location: San Francisco, CA
   date: 2024-06-13
   start_time: 17:00:00 PDT
@@ -1065,6 +1065,13 @@
   end_time: 19:00:00 EDT
   url: https://www.meetup.com/nyc-rb/events/301062985
 
+- name: Ruby Fusion - Milestones
+  location: Online
+  date: 2024-07-11
+  start_time: 18:30:00 MDT
+  end_time: 20:30:00 MDT
+  url: https://lu.ma/oyzfeg7u
+
 - name: 'Ruby Romania Meetup #05'
   location: Bucharest, Romania
   date: 2024-07-11
@@ -1107,7 +1114,7 @@
   end_time: 20:00:00 PDT
   url: https://www.meetup.com/sdruby/events/301083166
 
-- name: SF Bay Area Ruby Meetup in July @ Cisco Meraki
+- name: SF Bay Area Ruby - Meetup in July @ Cisco Meraki
   location: San Francisco, CA
   date: 2024-07-18
   start_time: 17:00:00 PDT
@@ -1240,8 +1247,8 @@
   end_time: 21:00:00 PDT
   url: https://events.ycombinator.com/yc-ruby-meetup
 
-- name: Boulder Ruby Group - Monthly Presentation Night
-  location: Boulder, CO / Online
+- name: Boulder Ruby - August 2024 Presentation Night
+  location: Boulder, CO
   date: 2024-08-14
   start_time: 18:00:00 MDT
   end_time: 20:30:00 MDT
@@ -1380,7 +1387,7 @@
   end_time: 20:00:00 EDT
   url: https://www.meetup.com/rubyjax/events/302836796
 
-- name: SF Bay Area Ruby Meetup in September @ GitHub HQ
+- name: SF Bay Area Ruby - Meetup in September @ GitHub
   location: San Francisco, CA
   date: 2024-09-03
   start_time: 17:00:00 PDT
@@ -1429,7 +1436,7 @@
   end_time: 13:00:00 EAT
   url: https://www.meetup.com/african_ruby_community/events/300548245
 
-- name: Boston Ruby Group - Project Night
+- name: Boston Ruby Group - Project Night September 2024
   location: Boston, MA
   date: 2024-09-09
   start_time: 18:00:00 EDT
@@ -1485,8 +1492,8 @@
   end_time: 20:30:00 EDT
   url: https://www.meetup.com/atlantaruby/events/302989742
 
-- name: Boulder Ruby Group - Monthly Presentation Night
-  location: Boulder, CO / Online
+- name: Boulder Ruby - September 2024 Presentation Night
+  location: Boulder, CO
   date: 2024-09-11
   start_time: 18:00:00 MDT
   end_time: 20:30:00 MDT
@@ -1775,7 +1782,7 @@
   end_time: 13:00:00 EAT
   url: https://www.meetup.com/african_ruby_community/events/hqdljtygcnbhb
 
-- name: Boston Ruby Group - Project Night
+- name: Boston Ruby Group - Project Night October 2024
   location: Boston, MA
   date: 2024-10-07
   start_time: 18:00:00 EDT
@@ -1831,8 +1838,8 @@
   end_time: 20:30:00 EDT
   url: https://www.meetup.com/atlantaruby/events/tczcxrygcnbmb
 
-- name: Boulder Ruby Group - Monthly Presentation Night
-  location: Boulder, CO / Online
+- name: Boulder Ruby - October 2024 Presentation Night
+  location: Boulder, CO
   date: 2024-10-09
   start_time: 18:00:00 MDT
   end_time: 20:30:00 MDT
@@ -1881,7 +1888,7 @@
   end_time: 21:00:00 CEST
   url: https://www.meetup.com/cologne-rb/events/302980609
 
-- name: SF Bay Area Ruby Meetup in October @ Chime HQ
+- name: SF Bay Area Ruby - Meetup in October @ Chime
   location: San Francisco, CA
   date: 2024-10-10
   start_time: 17:30:00 PDT
@@ -2042,11 +2049,11 @@
   end_time: 13:00:00 EAT
   url: https://www.meetup.com/african_ruby_community/events/hqdljtygcpbdb
 
-- name: Boston Ruby Group - Project Night
+- name: Boston Ruby Group - Project Night November 2024
   location: Boston, MA
   date: 2024-11-04
-  start_time: 18:00:00 EST
-  end_time: 20:00:00 EST
+  start_time: 18:00:00 EDT
+  end_time: 20:00:00 EDT
   url: https://lu.ma/zs5he82r
 
 - name: Bluegrass Ruby Users Group - November 2024
@@ -2154,11 +2161,11 @@
   end_time: 20:30:00 EDT
   url: https://www.meetup.com/atlantaruby/events/tczcxrygcpbrb
 
-- name: Boulder Ruby Group - Monthly Presentation Night
-  location: Boulder, CO / Online
+- name: Boulder Ruby - November 2024 Presentation Night
+  location: Boulder, CO
   date: 2024-11-13
-  start_time: 18:00:00 MST
-  end_time: 20:30:00 MST
+  start_time: 18:00:00 MDT
+  end_time: 20:30:00 MDT
   url: https://lu.ma/y1c2jita
 
 - name: Geneva.rb - Rails deployment with Kamal (Sean Carroll, GitLab)

--- a/src/events/abstract_event.rb
+++ b/src/events/abstract_event.rb
@@ -1,0 +1,71 @@
+require "forwardable"
+require "tzinfo"
+
+require_relative "../meetups_file_entry"
+
+class AbstractEvent
+  extend Forwardable
+
+  attr_reader :object, :group
+
+  def_delegators :meetup_file_entry, :name, :location, :date, :start_time, :end_time, :url
+
+  def initialize(object:, group:)
+    @object = object
+    @group = group
+  end
+
+  def tz
+    group.tz || TZInfo::Timezone.get(object.timezone)
+  end
+
+  def event_title
+    title = event_name.gsub(group.name, "").squeeze(" ").gsub(group.remove || "", "").strip
+
+    duplicate_names = group.upcoming_events.map { |event| event.event_name }.tally.select { |key, value| value >= 2 }
+
+    if duplicate_names.any?
+      title += " #{event_start_time.strftime("%B %Y")}" if duplicate_names.keys.include?(event_name)
+    end
+
+    title = "Meetup #{event_start_time.strftime("%B %Y")}" if title.blank?
+
+    "#{group.name} - #{title}".gsub(/^-+|-+$/, "").gsub("- -", "-").gsub("- :", "-").squeeze(" ").strip
+  end
+
+  def meetup_file_entry
+    @meetup_file_entry ||= MeetupsFileEntry.new(
+      name: event_title,
+      location: event_location,
+      date: event_start_time.iso8601,
+      start_time: [event_start_time.strftime("%H:%M:%S"), tz.now.strftime("%Z")].join(" "),
+      end_time: [event_end_time.strftime("%H:%M:%S"), tz.now.strftime("%Z")].join(" "),
+      url: event_url,
+      group: group,
+    )
+  end
+
+  def event_name
+    raise "Must implement event_name"
+  end
+
+  def event_start_time
+    raise "Must implement event_start_time"
+  end
+
+  def event_end_time
+    raise "Must implement event_end_time"
+  end
+
+  def event_location
+    raise "Must implement event_location"
+  end
+
+  def event_url
+    raise "Must implement event_url"
+  end
+
+  def service_id
+    raise "Must implement service_id"
+  end
+end

--- a/src/events/abstract_event.rb
+++ b/src/events/abstract_event.rb
@@ -10,6 +10,18 @@ class AbstractEvent
 
   def_delegators :meetup_file_entry, :name, :location, :date, :start_time, :end_time, :url
 
+  def self.service_id_for_url(url)
+    if url.start_with?("https://www.meetup.com/") || url.start_with?("https://meetup.com/")
+      return url.split("/").last
+    end
+
+    if url.start_with?("https://lu.ma/")
+      return url.split("/").last
+    end
+
+    nil
+  end
+
   def initialize(object:, group:)
     @object = object
     @group = group
@@ -45,6 +57,10 @@ class AbstractEvent
     )
   end
 
+  def service_id
+    self.class.service_id_for_url(event_url)
+  end
+
   def event_name
     raise "Must implement event_name"
   end
@@ -63,9 +79,5 @@ class AbstractEvent
 
   def event_url
     raise "Must implement event_url"
-  end
-
-  def service_id
-    raise "Must implement service_id"
   end
 end

--- a/src/events/luma_event.rb
+++ b/src/events/luma_event.rb
@@ -1,0 +1,41 @@
+require_relative "./abstract_event"
+
+class LumaEvent < AbstractEvent
+  def event_location
+    location = object.location.to_s
+
+    if location.start_with?("https://")
+      location = "Online"
+    else
+      location_parts = location.split(",").map(&:strip)
+      location_parts.delete("USA")
+
+      if (match = location_parts.last.match(/([A-Z]{2}) (\d{4,5})/))
+        location_parts.delete(location_parts.last)
+        location_parts << match[1]
+      end
+
+      location = location_parts.last(2).join(", ").strip
+    end
+  end
+
+  def event_name
+    object.summary
+  end
+
+  def event_start_time
+    tz.to_local(object.dtstart)
+  end
+
+  def event_end_time
+    tz.to_local(object.dtend)
+  end
+
+  def event_url
+    object.description.scan(/https:\/\/lu.ma\/.+/).first
+  end
+
+  def service_id
+    event_url.split("/").last
+  end
+end

--- a/src/events/luma_event.rb
+++ b/src/events/luma_event.rb
@@ -34,8 +34,4 @@ class LumaEvent < AbstractEvent
   def event_url
     object.description.scan(/https:\/\/lu.ma\/.+/).first
   end
-
-  def service_id
-    event_url.split("/").last
-  end
 end

--- a/src/events/meetup_event.rb
+++ b/src/events/meetup_event.rb
@@ -19,10 +19,6 @@ class MeetupEvent < AbstractEvent
     object.eventUrl
   end
 
-  def service_id
-    event_url.split("/").last
-  end
-
   def event_location
     city = object.dig("venue", "city") || object.dig("group", "city")
     state = object.dig("venue", "state") || object.dig("group", "state")

--- a/src/events/meetup_event.rb
+++ b/src/events/meetup_event.rb
@@ -1,0 +1,51 @@
+require "countries"
+
+require_relative "./abstract_event"
+
+class MeetupEvent < AbstractEvent
+  def event_name
+    object.title
+  end
+
+  def event_start_time
+    DateTime.parse(object.dateTime)
+  end
+
+  def event_end_time
+    DateTime.parse(object.endTime)
+  end
+
+  def event_url
+    object.eventUrl
+  end
+
+  def service_id
+    event_url.split("/").last
+  end
+
+  def event_location
+    city = object.dig("venue", "city") || object.dig("group", "city")
+    state = object.dig("venue", "state") || object.dig("group", "state")
+    country_raw = object.dig("venue", "country") || object.dig("group", "country")
+
+    country = ISO3166::Country.new(country_raw)
+
+    if object.isOnline
+      "Online"
+    elsif country.alpha2 == "US"
+      "#{city}, #{state.upcase}"
+    elsif country.alpha2 == "UK"
+      "#{city}, UK"
+    elsif country.alpha2 == "TW"
+      "#{city}, Taiwan"
+    elsif country.alpha2 == "DK"
+      "#{city == "1606" ? "Copenhagen" : city}, #{country&.iso_short_name}"
+    elsif country
+      "#{city}, #{country&.iso_short_name}"
+    elsif city
+      "#{city}, #{state}, #{country_raw.upcase}"
+    else
+      "Unknown"
+    end
+  end
+end

--- a/src/meetups_file.rb
+++ b/src/meetups_file.rb
@@ -35,13 +35,13 @@ class MeetupsFile
     MeetupGroup.all.each do |group|
       puts "Fetching #{group.service} Group: #{group.id}"
 
-      group.new_events.map { |event| group.openstruct_to_file_entry(event) }.each do |event|
+      group.new_events.map { |event| event.meetup_file_entry }.each do |event|
         @new_events << event
         @events << event
         puts "New Meetup: #{event.name} - #{event.date}"
       end
 
-      group.upcoming_events.map { |event| group.openstruct_to_file_entry(event) }.each do |event|
+      group.upcoming_events.map { |event| event.meetup_file_entry }.each do |event|
         event_entry = find_by(url: event.url)
 
         if event_entry && event != event_entry
@@ -51,7 +51,7 @@ class MeetupsFile
         end
       end
 
-      puts "\n"
+      puts
     end
 
     puts "New Events: #{@new_events.count}"

--- a/src/meetups_file.rb
+++ b/src/meetups_file.rb
@@ -32,8 +32,8 @@ class MeetupsFile
   end
 
   def fetch!
-    MeetupGroup.meetupdotcom.each do |group|
-      puts "Fetching Meetup.com Group: #{group.id}"
+    MeetupGroup.all.each do |group|
+      puts "Fetching #{group.service} Group: #{group.id}"
 
       group.new_events.map { |event| group.openstruct_to_file_entry(event) }.each do |event|
         @new_events << event

--- a/src/meetups_file_entry.rb
+++ b/src/meetups_file_entry.rb
@@ -26,8 +26,14 @@ MeetupsFileEntry = Data.define(:name, :location, :date, :start_time, :end_time, 
 
   def service_id
     if url.start_with?("https://www.meetup.com/") || url.start_with?("https://meetup.com/")
-      url.split("/").last
+      return url.split("/").last
     end
+
+    if url.start_with?("https://lu.ma/")
+      return url.split("/").last
+    end
+
+    nil
   end
 
   def to_hash

--- a/src/meetups_file_entry.rb
+++ b/src/meetups_file_entry.rb
@@ -20,20 +20,8 @@ MeetupsFileEntry = Data.define(:name, :location, :date, :start_time, :end_time, 
     )
   end
 
-  def self.from_frozen_record(record)
-    from_yaml_item(record.attributes)
-  end
-
   def service_id
-    if url.start_with?("https://www.meetup.com/") || url.start_with?("https://meetup.com/")
-      return url.split("/").last
-    end
-
-    if url.start_with?("https://lu.ma/")
-      return url.split("/").last
-    end
-
-    nil
+    AbstractEvent.service_id_for_url(url)
   end
 
   def to_hash

--- a/src/static/meetup.rb
+++ b/src/static/meetup.rb
@@ -3,7 +3,13 @@ require_relative "../static"
 class Meetup < FrozenRecord::Base
   def service_id
     if url.start_with?("https://www.meetup.com/") || url.start_with?("https://meetup.com/")
-      url.split("/").last
+      return url.split("/").last
     end
+
+    if url.start_with?("https://lu.ma/")
+      return url.split("/").last
+    end
+
+    nil
   end
 end

--- a/src/static/meetup.rb
+++ b/src/static/meetup.rb
@@ -1,6 +1,16 @@
 require_relative "../static"
 
 class Meetup < FrozenRecord::Base
+  def self.for_group(group)
+    if group.meetupdotcom?
+      Meetup.all.select { |meetup| meetup.url.include?(group.id) }
+    elsif group.luma?
+      Meetup.all.select { |meetup| meetup.name.include?(group.name) }
+    else
+      raise "Unsupported service: #{group.service}"
+    end
+  end
+
   def service_id
     if url.start_with?("https://www.meetup.com/") || url.start_with?("https://meetup.com/")
       return url.split("/").last

--- a/src/static/meetup.rb
+++ b/src/static/meetup.rb
@@ -12,14 +12,6 @@ class Meetup < FrozenRecord::Base
   end
 
   def service_id
-    if url.start_with?("https://www.meetup.com/") || url.start_with?("https://meetup.com/")
-      return url.split("/").last
-    end
-
-    if url.start_with?("https://lu.ma/")
-      return url.split("/").last
-    end
-
-    nil
+    AbstractEvent.service_id_for_url(url)
   end
 end

--- a/src/static/meetup_group.rb
+++ b/src/static/meetup_group.rb
@@ -1,6 +1,7 @@
 require "ostruct"
 require "tzinfo"
 require "countries"
+require "icalendar"
 
 require_relative "./meetup"
 require_relative "../static"
@@ -11,7 +12,7 @@ class MeetupGroup < FrozenRecord::Base
   scope :meetupdotcom, -> { where(service: "meetupdotcom" ) }
   scope :luma, -> { where(service: "luma" ) }
 
-  def upcoming_events
+  def upcoming_events_meetup
     @upcoming_events ||= begin
       result = MeetupClient::Client.query(EventsQuery, variables: { groupId: id })
 
@@ -30,8 +31,33 @@ class MeetupGroup < FrozenRecord::Base
     end
   end
 
-  def new_events
-    upcoming = upcoming_events || []
+  def upcoming_events_luma
+    ical_content = Net::HTTP.get(URI(ical_url))
+    calendars = Icalendar::Calendar.parse(ical_content)
+
+    events = calendars.first.events
+
+    if filter.present?
+      events = events.select { |event| event.summary.include?(filter) }
+    end
+
+    if exclude.present?
+      events = events.reject { |event| event.summary.include?(exclude) }
+    end
+
+    events
+  end
+
+  def upcoming_events
+    if service == "meetupdotcom"
+      upcoming_events_meetup
+    else
+      upcoming_events_luma
+    end
+  end
+
+  def new_events_meetup
+    upcoming = upcoming_events_meetup || []
     upcoming_ids = upcoming.map(&:id)
 
     new_event_ids = upcoming_ids - existing_event_ids
@@ -42,31 +68,97 @@ class MeetupGroup < FrozenRecord::Base
       .select { |event| Date.parse(event.dateTime).between?(Date.today - 1, Date.today + 90) }
   end
 
+  def new_events_luma
+    upcoming = upcoming_events_luma || []
+    upcoming_ids = upcoming.map { |event| event.description.scan(/https:\/\/lu.ma\/(.+)/).first.first }
+
+    new_event_ids = upcoming_ids - existing_event_ids
+
+    new_event_ids
+      .map { |new_id| upcoming.find { |upcoming| new_id == upcoming.description.scan(/https:\/\/lu.ma\/(.+)/).first.first } }
+      .sort_by(&:dtstart)
+      .select { |event| event.dtstart.between?(Date.today - 1, Date.today + 90) }
+  end
+
+  def new_events
+    if service == "meetupdotcom"
+      new_events_meetup
+    else
+      new_events_luma
+    end
+  end
+
   def existing_events
-    Meetup.all.select { |meetup| meetup.url.include?(id) }
+    if service == "meetupdotcom"
+      Meetup.all.select { |meetup| meetup.url.include?(id) }
+    else
+      Meetup.all.select { |meetup| meetup.name.include?(name) }
+    end
   end
 
   def existing_event_ids
     existing_events.map(&:service_id)
   end
 
+  def tz
+    return nil if timezone.nil?
+
+    @tz ||= TZInfo::Timezone.get(timezone)
+  end
+
   def openstruct_to_file_entry(event)
-    timezone = TZInfo::Timezone.get(event.timezone).now.strftime("%Z")
+    if service == "meetupdotcom"
+      openstruct_to_file_entry_meetup(event)
+    else
+      openstruct_to_file_entry_luma(event)
+    end
+  end
+
+  def openstruct_to_file_entry_meetup(event)
+    timezone = tz || TZInfo::Timezone.get(event.timezone)
 
     MeetupsFileEntry.new(
-      name: event_title(event),
+      name: event_title_meetup(event),
       location: event_to_location(event),
       date: Date.parse(event.dateTime).iso8601,
-      start_time: [Time.parse(event.dateTime).strftime("%H:%M:%S"), timezone].join(" "),
-      end_time: [Time.parse(event.endTime).strftime("%H:%M:%S"), timezone].join(" "),
+      start_time: [Time.parse(event.dateTime).strftime("%H:%M:%S"), timezone.now.strftime("%Z")].join(" "),
+      end_time: [Time.parse(event.endTime).strftime("%H:%M:%S"), timezone.now.strftime("%Z")].join(" "),
       url: event.eventUrl,
+      group: self,
+    )
+  end
+
+  def openstruct_to_file_entry_luma(event)
+    location = event.location.to_s
+
+    if location.start_with?("https://")
+      location = "Online"
+    else
+      location_parts = location.split(",").map(&:strip)
+      location_parts.delete("USA")
+
+      if (match = location_parts.last.match(/([A-Z]{2}) (\d{4,5})/))
+        location_parts.delete(location_parts.last)
+        location_parts << match[1]
+      end
+
+      location = location_parts.last(2).join(", ").strip
+    end
+
+    MeetupsFileEntry.new(
+      name: event_title_luma(event),
+      location: location,
+      date: tz.to_local(event.dtstart).iso8601,
+      start_time: [tz.to_local(event.dtstart).strftime("%H:%M:%S"), tz.now.strftime("%Z")].join(" "),
+      end_time: [tz.to_local(event.dtend).strftime("%H:%M:%S"), tz.now.strftime("%Z")].join(" "),
+      url: event.description.scan(/https:\/\/lu.ma\/.+/).first,
       group: self,
     )
   end
 
   private
 
-    def event_title(event)
+    def event_title_meetup(event)
       title = event.title.gsub(name, "").squeeze(" ").gsub(remove || "", "").strip
 
       duplicate_names = upcoming_events.map(&:title).tally.select { |key, value| value >= 2 }
@@ -76,6 +168,20 @@ class MeetupGroup < FrozenRecord::Base
       end
 
       title = "Meetup #{Date.parse(event.dateTime).strftime("%B %Y")}" if title.blank?
+
+      "#{name} - #{title}".gsub(/^-+|-+$/, "").gsub("- -", "-").gsub("- :", "-").squeeze(" ").strip
+    end
+
+    def event_title_luma(event)
+      title = event.summary.gsub(name, "").squeeze(" ").gsub(remove || "", "").strip
+
+      duplicate_names = upcoming_events.map(&:summary).tally.select { |key, value| value >= 2 }
+
+      if duplicate_names.any?
+        title += " #{tz.to_local(event.dtstart).strftime("%B %Y")}" if duplicate_names.keys.include?(event.summary)
+      end
+
+      title = "Meetup #{tz.to_local(event.dtstart).strftime("%B %Y")}" if title.blank?
 
       "#{name} - #{title}".gsub(/^-+|-+$/, "").gsub("- -", "-").gsub("- :", "-").squeeze(" ").strip
     end

--- a/src/static/meetup_group.rb
+++ b/src/static/meetup_group.rb
@@ -1,214 +1,72 @@
 require "ostruct"
 require "tzinfo"
-require "countries"
 require "icalendar"
 
 require_relative "./meetup"
 require_relative "../static"
 require_relative "../meetup_client"
+require_relative "../events/luma_event"
+require_relative "../events/meetup_event"
 require_relative "../queries/events_query"
 
 class MeetupGroup < FrozenRecord::Base
   scope :meetupdotcom, -> { where(service: "meetupdotcom" ) }
   scope :luma, -> { where(service: "luma" ) }
 
-  def upcoming_events_meetup
-    @upcoming_events ||= begin
-      result = MeetupClient::Client.query(EventsQuery, variables: { groupId: id })
-
-      events = Array(result.original_hash.dig("data", "groupByUrlname", "unifiedEvents", "edges"))
-      events = events.map { |event| OpenStruct.new(event["node"]) }
-
-      if filter.present?
-        events = events.select { |event| event.title.include?(filter) }
-      end
-
-      if exclude.present?
-        events = events.reject { |event| event.title.include?(exclude) }
-      end
-
-      events
-    end
-  end
-
-  def upcoming_events_luma
-    ical_content = Net::HTTP.get(URI(ical_url))
-    calendars = Icalendar::Calendar.parse(ical_content)
-
-    events = calendars.first.events
-
-    if filter.present?
-      events = events.select { |event| event.summary.include?(filter) }
-    end
-
-    if exclude.present?
-      events = events.reject { |event| event.summary.include?(exclude) }
-    end
-
-    events
-  end
-
   def upcoming_events
-    if service == "meetupdotcom"
-      upcoming_events_meetup
-    else
-      upcoming_events_luma
+    @upcoming_events ||= fetch_events.tap do |events|
+      events.select! { |event| event.name.include?(filter) } if filter.present?
+      events.reject! { |event| event.name.include?(exclude) } if exclude.present?
     end
-  end
-
-  def new_events_meetup
-    upcoming = upcoming_events_meetup || []
-    upcoming_ids = upcoming.map(&:id)
-
-    new_event_ids = upcoming_ids - existing_event_ids
-
-    new_event_ids
-      .map { |new_id| upcoming.find { |upcoming| new_id == upcoming.id } }
-      .sort_by(&:dateTime)
-      .select { |event| Date.parse(event.dateTime).between?(Date.today - 1, Date.today + 90) }
-  end
-
-  def new_events_luma
-    upcoming = upcoming_events_luma || []
-    upcoming_ids = upcoming.map { |event| event.description.scan(/https:\/\/lu.ma\/(.+)/).first.first }
-
-    new_event_ids = upcoming_ids - existing_event_ids
-
-    new_event_ids
-      .map { |new_id| upcoming.find { |upcoming| new_id == upcoming.description.scan(/https:\/\/lu.ma\/(.+)/).first.first } }
-      .sort_by(&:dtstart)
-      .select { |event| event.dtstart.between?(Date.today - 1, Date.today + 90) }
   end
 
   def new_events
-    if service == "meetupdotcom"
-      new_events_meetup
-    else
-      new_events_luma
-    end
+    existing_ids = existing_events.map(&:service_id)
+
+    upcoming_events
+      .select { |event| !existing_ids.include?(event.service_id) }
+      .select { |event| event.date.between?(Date.today - 1, Date.today + 120) }
+      .sort_by { |event| [event.date, event.name] }
   end
 
   def existing_events
-    if service == "meetupdotcom"
-      Meetup.all.select { |meetup| meetup.url.include?(id) }
-    else
-      Meetup.all.select { |meetup| meetup.name.include?(name) }
-    end
+    Meetup.for_group(self)
   end
 
-  def existing_event_ids
-    existing_events.map(&:service_id)
+  def meetupdotcom?
+    service == "meetupdotcom"
+  end
+
+  def luma?
+    service == "luma"
   end
 
   def tz
-    return nil if timezone.nil?
-
-    @tz ||= TZInfo::Timezone.get(timezone)
-  end
-
-  def openstruct_to_file_entry(event)
-    if service == "meetupdotcom"
-      openstruct_to_file_entry_meetup(event)
-    else
-      openstruct_to_file_entry_luma(event)
-    end
-  end
-
-  def openstruct_to_file_entry_meetup(event)
-    timezone = tz || TZInfo::Timezone.get(event.timezone)
-
-    MeetupsFileEntry.new(
-      name: event_title_meetup(event),
-      location: event_to_location(event),
-      date: Date.parse(event.dateTime).iso8601,
-      start_time: [Time.parse(event.dateTime).strftime("%H:%M:%S"), timezone.now.strftime("%Z")].join(" "),
-      end_time: [Time.parse(event.endTime).strftime("%H:%M:%S"), timezone.now.strftime("%Z")].join(" "),
-      url: event.eventUrl,
-      group: self,
-    )
-  end
-
-  def openstruct_to_file_entry_luma(event)
-    location = event.location.to_s
-
-    if location.start_with?("https://")
-      location = "Online"
-    else
-      location_parts = location.split(",").map(&:strip)
-      location_parts.delete("USA")
-
-      if (match = location_parts.last.match(/([A-Z]{2}) (\d{4,5})/))
-        location_parts.delete(location_parts.last)
-        location_parts << match[1]
-      end
-
-      location = location_parts.last(2).join(", ").strip
-    end
-
-    MeetupsFileEntry.new(
-      name: event_title_luma(event),
-      location: location,
-      date: tz.to_local(event.dtstart).iso8601,
-      start_time: [tz.to_local(event.dtstart).strftime("%H:%M:%S"), tz.now.strftime("%Z")].join(" "),
-      end_time: [tz.to_local(event.dtend).strftime("%H:%M:%S"), tz.now.strftime("%Z")].join(" "),
-      url: event.description.scan(/https:\/\/lu.ma\/.+/).first,
-      group: self,
-    )
+    @tz ||= timezone && TZInfo::Timezone.get(timezone)
   end
 
   private
 
-    def event_title_meetup(event)
-      title = event.title.gsub(name, "").squeeze(" ").gsub(remove || "", "").strip
-
-      duplicate_names = upcoming_events.map(&:title).tally.select { |key, value| value >= 2 }
-
-      if duplicate_names.any?
-        title += " #{Date.parse(event.dateTime).strftime("%B %Y")}" if duplicate_names.keys.include?(event.title)
-      end
-
-      title = "Meetup #{Date.parse(event.dateTime).strftime("%B %Y")}" if title.blank?
-
-      "#{name} - #{title}".gsub(/^-+|-+$/, "").gsub("- -", "-").gsub("- :", "-").squeeze(" ").strip
+  def fetch_events
+    case service
+    when "meetupdotcom"
+      fetch_meetup_events
+    when "luma"
+      fetch_luma_events
+    else
+      raise "Unsupported service: #{service}"
     end
+  end
 
-    def event_title_luma(event)
-      title = event.summary.gsub(name, "").squeeze(" ").gsub(remove || "", "").strip
+  def fetch_meetup_events
+    result = MeetupClient::Client.query(EventsQuery, variables: { groupId: id })
+    events = Array(result.original_hash.dig("data", "groupByUrlname", "unifiedEvents", "edges"))
+    events.map { |event| MeetupEvent.new(object: OpenStruct.new(event["node"]), group: self) }
+  end
 
-      duplicate_names = upcoming_events.map(&:summary).tally.select { |key, value| value >= 2 }
-
-      if duplicate_names.any?
-        title += " #{tz.to_local(event.dtstart).strftime("%B %Y")}" if duplicate_names.keys.include?(event.summary)
-      end
-
-      title = "Meetup #{tz.to_local(event.dtstart).strftime("%B %Y")}" if title.blank?
-
-      "#{name} - #{title}".gsub(/^-+|-+$/, "").gsub("- -", "-").gsub("- :", "-").squeeze(" ").strip
-    end
-
-    def event_to_location(event)
-      city = event.dig("venue", "city") || event.dig("group", "city")
-      state = event.dig("venue", "state") || event.dig("group", "state")
-      country_raw = event.dig("venue", "country") || event.dig("group", "country")
-
-      country = ISO3166::Country.new(country_raw)
-
-      if event.isOnline
-        "Online"
-      elsif country.alpha2 == "US"
-        "#{city}, #{state.upcase}"
-      elsif country.alpha2 == "UK"
-        "#{city}, UK"
-      elsif country.alpha2 == "TW"
-        "#{city}, Taiwan"
-      elsif country.alpha2 == "DK"
-        "#{city == "1606" ? "Copenhagen" : city}, #{country&.iso_short_name}"
-      elsif country
-        "#{city}, #{country&.iso_short_name}"
-      elsif city
-        "#{city}, #{state}, #{country_raw.upcase}"
-      else
-        "Unknown"
-      end
-    end
+  def fetch_luma_events
+    ical_content = Net::HTTP.get(URI(ical_url))
+    calendars = Icalendar::Calendar.parse(ical_content)
+    calendars.first.events.map { |event| LumaEvent.new(object: event, group: self) }
+  end
 end


### PR DESCRIPTION
Similar to #720, but for automatically fetching events from [Luma](https://lu.ma) or any ical calendar.

Additionally adds the Ruby Fusion and Madison+ Ruby Luma Meetup Groups.

Resolves https://github.com/ruby-conferences/ruby-conferences.github.io/issues/723
