### PR TITLE
Automate fetching meetups from ical calendars

### DIFF
--- a/_data/meetup_groups.yml
+++ b/_data/meetup_groups.yml
@@ -44,7 +44,9 @@
 - id: atlantaruby
   name: Atlanta Ruby
   service: meetupdotcom
-  remove: "[VIRTUAL] "
+  remove:
+    - "[VIRTUAL] "
+    - "The Atlanta Ruby Meetup Group"
 
 - id: aucklandruby
   name: Auckland Ruby
@@ -166,6 +168,8 @@
 - id: cologne-rb
   name: Cologne.rb
   service: meetupdotcom
+  remove:
+    - "Ruby Usergroup: "
 
 - id: columbus-ruby-on-rails-mind-meld
   name: Columbus Ruby
@@ -253,8 +257,11 @@
   service: meetupdotcom
 
 - id: indyrb
-  name: Indy.rb
+  name: Indianapolis Ruby Brigade
   service: meetupdotcom
+  remove:
+    - "The Indianapolis Ruby Brigade"
+    - "Indy.rb"
 
 - id: israel-rb
   name: israel.rb
@@ -425,10 +432,12 @@
   service: meetupdotcom
 
 - id: ocruby
-  name: Orange County Ruby Users Group
+  name: Orange County Ruby
   service: meetupdotcom
   exclude: Rails Camp
-  remove: "(OCRuby)"
+  remove:
+    - "(OCRuby)"
+    - "Orange County Ruby Users Group"
 
 - id: odense-rb
   name: odense.rb
@@ -668,8 +677,10 @@
   service: meetupdotcom
 
 - id: ruby-on-rails-oceania-melbourne
-  name: Ruby and Rails Melbourne
+  name: Melbourne Ruby
   service: meetupdotcom
+  remove:
+    - "Melbourne Ruby"
 
 - id: ruby-on-rails-oceania-perth
   name: Ruby and Rails Perth
@@ -933,9 +944,11 @@
   service: meetupdotcom
 
 - id: the-bluegrass-developers-guild
-  name: Bluegrass Ruby Users Group
+  name: Bluegrass Ruby
   filter: Bluegrass Ruby
   service: meetupdotcom
+  remove:
+    - Bluegrass Ruby Users Group
 
 - id: the-seattle-ruby-on-rails-developers-meetup-group
   name: Seattle Ruby on Rails

--- a/_data/meetup_groups.yml
+++ b/_data/meetup_groups.yml
@@ -11,7 +11,9 @@
 - id: african_ruby_community
   name: African Ruby Community
   service: meetupdotcom
-  remove: ARC
+  remove:
+    - "ARC"
+    - "(Zoom)"
 
 - id: aloharb
   name: aloha.rb
@@ -326,11 +328,11 @@
   name: London Learn Ruby
   service: meetupdotcom
 
-- id: london-ruby-user-group
-  name: London Ruby User Group
-  service: ical
-  ical_url: https://lrug.org/meeting-calendar
-  timezone: Europe/London
+# - id: london-ruby-user-group
+#   name: London Ruby User Group
+#   service: ical
+#   ical_url: https://lrug.org/meeting-calendar
+#   timezone: Europe/London
 
 - id: lyonrb
   name: Lyon.rb
@@ -861,6 +863,12 @@
   name: SD Ruby
   service: meetupdotcom
 
+# - id: seattle-rb
+#   name: Seattle.rb
+#   service: ical
+#   timezone: America/Los_Angeles
+#   ical_url: https://seattlerb.org/events.ics
+
 - id: seoul-ruby-meetup
   name: Seoul Ruby Meetup
   service: meetupdotcom
@@ -958,14 +966,14 @@
   service: meetupdotcom
 
 - id: torontoruby
-  name: Toronto Ruby Brigade
+  name: Toronto Ruby
   service: meetupdotcom
 
-- id: toronto-ruby
-  name: Toronto Ruby
-  service: ical
-  timezone: America/Toronto
-  ical_url: https://toronto-ruby.com/events/all.ics
+# - id: toronto-ruby
+#   name: Toronto Ruby
+#   service: ical
+#   timezone: America/Toronto
+#   ical_url: https://toronto-ruby.com/events/all.ics
 
 - id: toulouse-ruby-friends
   name: Toulouse.rb

--- a/_data/meetup_groups.yml
+++ b/_data/meetup_groups.yml
@@ -714,6 +714,7 @@
   remove:
     - "(watch the date)"
     - "Check the date!"
+    - "CANCELED"
 
 - id: ruby-usergroup-hamburg
   name: Ruby Usergroup Hamburg

--- a/_data/meetup_groups.yml
+++ b/_data/meetup_groups.yml
@@ -21,6 +21,12 @@
   name: Amsterdam.rb
   service: meetupdotcom
 
+- id: andalucia-rb
+  name: Andalucia.rb
+  service: ical
+  timezone: Europe/Madrid
+  ical_url: https://andalucia.onruby.eu/events.ics
+
 - id: arlington-ruby
   name: Arlington Ruby
   service: meetupdotcom
@@ -335,6 +341,13 @@
   service: luma
   ical_url: https://api.lu.ma/ics/get?entity=calendar&id=cal-LlD9HPh8QnHgqEQ
   timezone: America/Chicago
+
+- id: madrid-rb
+  name: Madrid.rb
+  service: ical
+  timezone: Europe/Madrid
+  default_location: Madrid, Spain
+  ical_url: https://www.madridrb.com/events.ics
 
 - id: medellin-rb
   name: Medellín.rb
@@ -689,8 +702,40 @@
   service: meetupdotcom
 
 - id: ruby-user-group-linz-rugl
-  name: Ruby User Group Linz (RUGL)
+  name: Ruby User Group Linz
   service: meetupdotcom
+
+- id: ruby-user-group-berlin
+  name: Ruby User Group Berlin
+  service: ical
+  timezone: Europe/Berlin
+  default_location: Berlin, Germany
+  ical_url: https://www.rug-b.de/events.ics
+  remove:
+    - "(watch the date)"
+    - "Check the date!"
+
+- id: ruby-usergroup-hamburg
+  name: Ruby Usergroup Hamburg
+  service: ical
+  timezone: Europe/Berlin
+  default_location: Hamburg, Germany
+  ical_url: https://hamburg.onruby.de/events.ics
+
+- id: ruby-user-group-cologne
+  name: Ruby User Group Cologne
+  service: ical
+  timezone: Europe/Berlin
+  default_location: Cologne, Germany
+  ical_url: https://www.colognerb.de/events.ics
+  remove: "Kölsch.rb"
+
+- id: ruby-user-group-leipzig
+  name: Ruby User Group Leipzig
+  service: ical
+  timezone: Europe/Berlin
+  default_location: Leipzig, Germany
+  ical_url: https://leipzig.onruby.de/events.ics
 
 # - id: ruby-user-group-saarland
 #   name:
@@ -709,11 +754,11 @@
   service: meetupdotcom
 
 - id: rubydf
-  name: Ruby DF
+  name: RubyDF
   service: meetupdotcom
 
 - id: rubydf
-  name: Ruby DF
+  name: RubyDF
   timezone: America/Sao_Paulo
   ical_url: https://rubydf.com/events.ics
   service: ical

--- a/_data/meetup_groups.yml
+++ b/_data/meetup_groups.yml
@@ -320,6 +320,12 @@
   name: London Learn Ruby
   service: meetupdotcom
 
+- id: london-ruby-user-group
+  name: London Ruby User Group
+  service: ical
+  ical_url: https://lrug.org/meeting-calendar
+  timezone: Europe/London
+
 - id: lyonrb
   name: Lyon.rb
   service: meetupdotcom
@@ -706,6 +712,12 @@
   name: Ruby DF
   service: meetupdotcom
 
+- id: rubydf
+  name: Ruby DF
+  timezone: America/Sao_Paulo
+  ical_url: https://rubydf.com/events.ics
+  service: ical
+
 - id: rubyfloripa
   name: RubyFloripa
   service: meetupdotcom
@@ -902,6 +914,12 @@
 - id: torontoruby
   name: Toronto Ruby Brigade
   service: meetupdotcom
+
+- id: toronto-ruby
+  name: Toronto Ruby
+  service: ical
+  timezone: America/Toronto
+  ical_url: https://toronto-ruby.com/events/all.ics
 
 - id: toulouse-ruby-friends
   name: Toulouse.rb

--- a/_data/meetups.yml
+++ b/_data/meetups.yml
@@ -261,7 +261,7 @@
   end_time: 21:00:00 EST
   url: https://radius.to/groups/toronto-ruby/events/vxmd8kyaxs3t
 
-- name: Bluegrass Ruby Users Group - March 2024
+- name: Bluegrass Ruby - March 2024
   location: Lexington, KY
   date: 2024-03-05
   start_time: 18:00:00 EST
@@ -457,7 +457,7 @@
   end_time: 22:00:00 UYT
   url: https://www.meetup.com/ruby-montevideo/events/299957596
 
-- name: Bluegrass Ruby Users Group - April 2024
+- name: Bluegrass Ruby - April 2024
   location: Lexington, KY
   date: 2024-04-02
   start_time: 18:00:00 EDT
@@ -751,7 +751,7 @@
   end_time: 21:00:00 PDT
   url: https://lu.ma/sfruby-may24
 
-- name: Bluegrass Ruby Users Group - May 2024
+- name: Bluegrass Ruby - May 2024
   location: Lexington, KY
   date: 2024-05-21
   start_time: 18:00:00 EDT
@@ -849,7 +849,7 @@
   end_time: 20:30:00 EDT
   url: https://www.meetup.com/bostonrb/events/300772513
 
-- name: Bluegrass Ruby Users Group - June 2024
+- name: Bluegrass Ruby - June 2024
   location: Lexington, KY
   date: 2024-06-04
   start_time: 18:00:00 EDT
@@ -1059,7 +1059,7 @@
   end_time: 20:00:00 EDT
   url: https://www.meetup.com/bostonrb/events/301084091
 
-- name: Bluegrass Ruby Users Group - July 2024
+- name: Bluegrass Ruby - July 2024
   location: Lexington, KY
   date: 2024-07-02
   start_time: 18:00:00 EDT
@@ -1270,7 +1270,7 @@
   end_time: 20:00:00 EDT
   url: https://www.meetup.com/bostonrb/events/301905492
 
-- name: Bluegrass Ruby Users Group - August 2024
+- name: Bluegrass Ruby - August 2024
   location: Lexington, KY
   date: 2024-08-06
   start_time: 18:00:00 EDT
@@ -1424,7 +1424,7 @@
   end_time: 20:30:00 CDT
   url: https://www.meetup.com/austinrb/events/302551912
 
-- name: Orange County Ruby Users Group - Meetup August 2024
+- name: Orange County Ruby - Meetup August 2024
   location: Dana Point, CA
   date: 2024-08-29
   start_time: 19:00:00 PDT
@@ -1453,14 +1453,14 @@
   url: https://www.meetup.com/punerubymeetup/events/302884102
   status: cancelled
 
-- name: Orange County Ruby Users Group - Ruby Science September 2024
+- name: Orange County Ruby - Ruby Science September 2024
   location: Online
   date: 2024-09-02
   start_time: 10:00:00 PDT
   end_time: 11:00:00 PDT
   url: https://www.meetup.com/ocruby/events/302809972
 
-- name: Bluegrass Ruby Users Group - September
+- name: Bluegrass Ruby - September
   location: Lexington, KY
   date: 2024-09-03
   start_time: 18:00:00 EDT
@@ -1608,7 +1608,7 @@
   end_time: 21:00:00 PDT
   url: https://www.meetup.com/vancouver-ruby/events/302810382
 
-- name: Atlanta Ruby - The Meetup Group Monthly Meetup September 2024
+- name: Atlanta Ruby - Monthly Meetup September 2024
   location: Online
   date: 2024-09-11
   start_time: 18:30:00 EDT
@@ -1629,7 +1629,7 @@
   end_time: 20:00:00 CEST
   url: https://www.meetup.com/copenhagen-ruby-brigade/events/302958358
 
-- name: Indy.rb - The Indianapolis Ruby Brigade Monthly Meetup September 2024
+- name: Indianapolis Ruby Brigade - Monthly Meetup September 2024
   location: Indianapolis, IN
   date: 2024-09-11
   start_time: 19:00:00 EDT
@@ -1671,8 +1671,7 @@
   end_time: 23:00:00 CEST
   url: https://hamburg.onruby.de/events/ruby-usergroup-hamburg-september-2024-914
 
-- name: 'African Ruby Community - Ruby Thursdays: To be determined (Zoom) September
-    2024'
+- name: 'African Ruby Community - Ruby Thursdays: To be determined September 2024'
   location: Online
   date: 2024-09-12
   start_time: 18:00:00 EAT
@@ -1693,7 +1692,7 @@
   end_time: 21:00:00 EDT
   url: https://www.meetup.com/miamirb/events/303077048
 
-- name: Orange County Ruby Users Group - Ruby Science September 2024
+- name: Orange County Ruby - Ruby Science September 2024
   location: Online
   date: 2024-09-16
   start_time: 10:00:00 PDT
@@ -1842,28 +1841,28 @@
   end_time: 10:00:00 CDT
   url: https://www.meetup.com/austinrb/events/302552064
 
-- name: Orange County Ruby Users Group - Meetup September 2024
-  location: Dana Point, CA
-  date: 2024-09-26
-  start_time: 19:00:00 PDT
-  end_time: 21:00:00 PDT
-  url: https://www.meetup.com/ocruby/events/pbgwwqygcmbjc
-
-- name: Ruby and Rails Melbourne - Melbourne Ruby September 2024
+- name: Melbourne Ruby - September 2024
   location: Southbank, Australia
   date: 2024-09-26
   start_time: 18:00:00 AEST
   end_time: 21:00:00 AEST
   url: https://www.meetup.com/ruby-on-rails-oceania-melbourne/events/297781285
 
-- name: Orange County Ruby Users Group - Ruby Science September 2024
+- name: Orange County Ruby - Meetup September 2024
+  location: Dana Point, CA
+  date: 2024-09-26
+  start_time: 19:00:00 PDT
+  end_time: 21:00:00 PDT
+  url: https://www.meetup.com/ocruby/events/pbgwwqygcmbjc
+
+- name: Orange County Ruby - Ruby Science September 2024
   location: Online
   date: 2024-09-30
   start_time: 10:00:00 PDT
   end_time: 11:00:00 PDT
   url: https://www.meetup.com/ocruby/events/sdczltygcmbnc
 
-- name: Bluegrass Ruby Users Group - October 2024
+- name: Bluegrass Ruby - October 2024
   location: Lexington, KY
   date: 2024-10-01
   start_time: 18:00:00 EDT
@@ -1990,7 +1989,7 @@
   end_time: 21:00:00 MDT
   url: https://www.meetup.com/utah-ruby-users-group/events/302950248
 
-- name: Atlanta Ruby - The Meetup Group Monthly Meetup October 2024
+- name: Atlanta Ruby - Monthly Meetup October 2024
   location: Online
   date: 2024-10-09
   start_time: 18:30:00 EDT
@@ -2004,7 +2003,7 @@
   end_time: 20:30:00 MDT
   url: https://lu.ma/57vrruyr
 
-- name: Indy.rb - The Indianapolis Ruby Brigade Monthly Meetup October 2024
+- name: Indianapolis Ruby Brigade - Monthly Meetup October 2024
   location: Indianapolis, IN
   date: 2024-10-09
   start_time: 19:00:00 EDT
@@ -2032,15 +2031,14 @@
   end_time: 19:00:00 CST
   url: https://www.meetup.com/rails-taiwan/events/qxfvjkygcnbmb
 
-- name: 'African Ruby Community - Ruby Thursdays: To be determined (Zoom) October
-    2024'
+- name: 'African Ruby Community - Ruby Thursdays: To be determined October 2024'
   location: Online
   date: 2024-10-10
   start_time: 18:00:00 EAT
   end_time: 20:00:00 EAT
   url: https://www.meetup.com/african_ruby_community/events/301578294
 
-- name: 'Cologne.rb - Ruby Usergroup: Oktober 2024 Meetup'
+- name: Cologne.rb - Oktober 2024 Meetup
   location: Köln, Germany
   date: 2024-10-10
   start_time: 19:00:00 CEST
@@ -2054,7 +2052,7 @@
   end_time: 21:00:00 PDT
   url: https://lu.ma/jfpfmh19
 
-- name: Orange County Ruby Users Group - Ruby Science October 2024
+- name: Orange County Ruby - Ruby Science October 2024
   location: Online
   date: 2024-10-14
   start_time: 10:00:00 PDT
@@ -2159,14 +2157,14 @@
   end_time: 20:30:00 CDT
   url: https://www.meetup.com/austinrb/events/302552273
 
-- name: Ruby and Rails Melbourne - Melbourne Ruby October 2024
+- name: Melbourne Ruby - October 2024
   location: Southbank, Australia
   date: 2024-10-24
   start_time: 18:00:00 AEST
   end_time: 21:00:00 AEST
   url: https://www.meetup.com/ruby-on-rails-oceania-melbourne/events/297781289
 
-- name: Orange County Ruby Users Group - Ruby Science October 2024
+- name: Orange County Ruby - Ruby Science October 2024
   location: Online
   date: 2024-10-28
   start_time: 10:00:00 PDT
@@ -2187,7 +2185,7 @@
   end_time: 19:00:00 CST
   url: https://www.meetup.com/rails-taiwan/events/qxfvjkygcnbnc
 
-- name: Orange County Ruby Users Group - Meetup October 2024
+- name: Orange County Ruby - Meetup October 2024
   location: Dana Point, CA
   date: 2024-10-31
   start_time: 19:00:00 PDT
@@ -2215,7 +2213,7 @@
   end_time: 20:00:00 EDT
   url: https://lu.ma/zs5he82r
 
-- name: Bluegrass Ruby Users Group - November 2024
+- name: Bluegrass Ruby - November 2024
   location: Lexington, KY
   date: 2024-11-05
   start_time: 18:00:00 EDT
@@ -2271,7 +2269,7 @@
   end_time: 21:00:00 PDT
   url: https://www.meetup.com/sdruby/events/hjmpmtygcpbkb
 
-- name: Orange County Ruby Users Group - Ruby Science November 2024
+- name: Orange County Ruby - Ruby Science November 2024
   location: Online
   date: 2024-11-11
   start_time: 10:00:00 PDT
@@ -2314,7 +2312,7 @@
   end_time: 21:00:00 MDT
   url: https://www.meetup.com/utah-ruby-users-group/events/302953305
 
-- name: Atlanta Ruby - The Meetup Group Monthly Meetup November 2024
+- name: Atlanta Ruby - Monthly Meetup November 2024
   location: Online
   date: 2024-11-13
   start_time: 18:30:00 EDT
@@ -2335,7 +2333,7 @@
   end_time: 21:00:00 CEST
   url: https://www.meetup.com/geneva-rb/events/303018670
 
-- name: Indy.rb - The Indianapolis Ruby Brigade Monthly Meetup November 2024
+- name: Indianapolis Ruby Brigade - Monthly Meetup November 2024
   location: Indianapolis, IN
   date: 2024-11-13
   start_time: 19:00:00 EDT
@@ -2370,8 +2368,7 @@
   end_time: 21:00:00 CEST
   url: https://hamburg.onruby.de/events/ruby-usergroup-hamburg-november-2024-915
 
-- name: 'African Ruby Community - Ruby Thursdays: To be determined (Zoom) November
-    2024'
+- name: 'African Ruby Community - Ruby Thursdays: To be determined November 2024'
   location: Online
   date: 2024-11-14
   start_time: 18:00:00 EAT
@@ -2448,7 +2445,7 @@
   end_time: 20:00:00 PDT
   url: https://www.meetup.com/portland-ruby-brigade/events/qtnwktygcpbcc
 
-- name: Orange County Ruby Users Group - Ruby Science November 2024
+- name: Orange County Ruby - Ruby Science November 2024
   location: Online
   date: 2024-11-25
   start_time: 10:00:00 PDT
@@ -2476,19 +2473,19 @@
   end_time: 20:30:00 CEST
   url: https://www.meetup.com/rubyonrails-ch/events/301751612
 
-- name: Orange County Ruby Users Group - Meetup November 2024
-  location: Dana Point, CA
-  date: 2024-11-28
-  start_time: 19:00:00 PDT
-  end_time: 21:00:00 PDT
-  url: https://www.meetup.com/ocruby/events/pbgwwqygcpblc
-
-- name: Ruby and Rails Melbourne - Melbourne Ruby November 2024
+- name: Melbourne Ruby - November 2024
   location: Southbank, Australia
   date: 2024-11-28
   start_time: 18:00:00 AEST
   end_time: 21:00:00 AEST
   url: https://www.meetup.com/ruby-on-rails-oceania-melbourne/events/297781304
+
+- name: Orange County Ruby - Meetup November 2024
+  location: Dana Point, CA
+  date: 2024-11-28
+  start_time: 19:00:00 PDT
+  end_time: 21:00:00 PDT
+  url: https://www.meetup.com/ocruby/events/pbgwwqygcpblc
 
 - name: Ruby and Rails Adelaide - Ruby Burgers November 2024
   location: Adelaide, Australia
@@ -2504,7 +2501,7 @@
   end_time: 13:00:00 EAT
   url: https://www.meetup.com/african_ruby_community/events/301647150
 
-- name: Bluegrass Ruby Users Group - December 2024
+- name: Bluegrass Ruby - December 2024
   location: Lexington, KY
   date: 2024-12-03
   start_time: 18:00:00 EDT
@@ -2560,7 +2557,7 @@
   end_time: 21:00:00 PDT
   url: https://www.meetup.com/sdruby/events/hjmpmtygcqbhb
 
-- name: Orange County Ruby Users Group - Ruby Science December 2024
+- name: Orange County Ruby - Ruby Science December 2024
   location: Online
   date: 2024-12-09
   start_time: 10:00:00 PDT
@@ -2603,7 +2600,7 @@
   end_time: 21:00:00 MDT
   url: https://www.meetup.com/utah-ruby-users-group/events/302953317
 
-- name: Atlanta Ruby - The Meetup Group Monthly Meetup December 2024
+- name: Atlanta Ruby - Monthly Meetup December 2024
   location: Online
   date: 2024-12-11
   start_time: 18:30:00 EDT
@@ -2617,7 +2614,7 @@
   end_time: 21:00:00 CEST
   url: https://www.meetup.com/geneva-rb/events/303018673
 
-- name: Indy.rb - The Indianapolis Ruby Brigade Monthly Meetup December 2024
+- name: Indianapolis Ruby Brigade - Monthly Meetup December 2024
   location: Indianapolis, IN
   date: 2024-12-11
   start_time: 19:00:00 EDT
@@ -2652,8 +2649,7 @@
   end_time: 21:00:00 CEST
   url: https://hamburg.onruby.de/events/ruby-usergroup-hamburg-chrismas-edition-dezember-2024-916
 
-- name: 'African Ruby Community - Ruby Thursdays: To be determined (Zoom) December
-    2024'
+- name: 'African Ruby Community - Ruby Thursdays: To be determined December 2024'
   location: Online
   date: 2024-12-12
   start_time: 18:00:00 EAT
@@ -2716,7 +2712,7 @@
   end_time: 20:00:00 PDT
   url: https://www.meetup.com/portland-ruby-brigade/events/qtnwktygcqbzb
 
-- name: Orange County Ruby Users Group - Ruby Science December 2024
+- name: Orange County Ruby - Ruby Science December 2024
   location: Online
   date: 2024-12-23
   start_time: 10:00:00 PDT
@@ -2737,7 +2733,7 @@
   end_time: 19:00:00 CST
   url: https://www.meetup.com/rails-taiwan/events/qxfvjkygcqbhc
 
-- name: Orange County Ruby Users Group - Meetup December 2024
+- name: Orange County Ruby - Meetup December 2024
   location: Dana Point, CA
   date: 2024-12-26
   start_time: 19:00:00 PDT

--- a/_data/meetups.yml
+++ b/_data/meetups.yml
@@ -147,7 +147,7 @@
   date: 2024-02-03
   start_time: 10:00:00 -03
   end_time: 12:00:00 -03
-  url: https://rubydf.com/events/segunda-edicao/
+  url: https://rubydf.com/events/segunda-edicao
 
 - name: ChicagoRuby - Jason Swett "How to Write Meaningful Tests"
   location: Chicago, IL
@@ -441,7 +441,7 @@
   date: 2024-04-02
   start_time: 18:00:00 EDT
   end_time: 20:00:00 EDT
-  url: https://www.meetup.com/the-bluegrass-developers-guild/events/300021220/
+  url: https://www.meetup.com/the-bluegrass-developers-guild/events/300021220
 
 - name: Boston Ruby Group - Project Night
   location: Boston, MA
@@ -637,7 +637,7 @@
   date: 2024-05-09
   start_time: 18:00:00 HKT
   end_time: 20:00:00 HKT
-  url: https://www.facebook.com/events/758719776072660/
+  url: https://www.facebook.com/events/758719776072660
 
 - name: Ruby Fusion - Meetup May 2024
   location: Online
@@ -777,14 +777,14 @@
   date: 2024-05-29
   start_time: 18:00:00 BRT
   end_time: 22:00:00 BRT
-  url: http://frevoonrails.com.br/posts,/events/2024/05/10/encontro-de-maio-2024/
+  url: http://frevoonrails.com.br/posts,/events/2024/05/10/encontro-de-maio-2024
 
 - name: Helsinki Ruby Brigade - Summer kick-off
   location: Helsinki, Finland
   date: 2024-05-29
   start_time: 17:30:00 EEST
   end_time: 20:30:00 EEST
-  url: https://rubybrigade.fi/event/2024/summer-kick-off/
+  url: https://rubybrigade.fi/event/2024/summer-kick-off
 
 - name: Austin.rb - Ruby Social (Morning)
   location: Austin, TX
@@ -819,7 +819,7 @@
   date: 2024-06-04
   start_time: 18:00:00 EDT
   end_time: 20:00:00 EDT
-  url: https://bluegrassruby.club/
+  url: https://bluegrassruby.club
 
 - name: Charlotte Ruby - Ruby Hack Night June 2024
   location: Online
@@ -896,7 +896,7 @@
   date: 2024-06-11
   start_time: 18:30:00 CDT
   end_time: 20:30:00 CDT
-  url: https://www.meetup.com/austinrb/events/297610742/
+  url: https://www.meetup.com/austinrb/events/297610742
 
 - name: Boston Ruby Group - June 2024 meeting
   location: Boston, MA
@@ -1008,7 +1008,7 @@
   date: 2024-06-27
   start_time: 18:30:00 CDT
   end_time: 20:30:00 CDT
-  url: https://www.meetup.com/austinrb/events/300256966/
+  url: https://www.meetup.com/austinrb/events/300256966
 
 - name: Philippine Ruby Users Group - Heading Hybrid
   location: Multi-location hydrid (Makati & Batangas City, Philippines)
@@ -1065,7 +1065,7 @@
   date: 2024-07-09
   start_time: 18:30:00 CDT
   end_time: 20:30:00 CDT
-  url: https://www.meetup.com/austinrb/events/297610747/
+  url: https://www.meetup.com/austinrb/events/297610747
 
 - name: Boston Ruby Group - July 2024 meeting
   location: Boston, MA
@@ -1128,7 +1128,7 @@
   date: 2024-07-11
   start_time: 19:00:00 EEST
   end_time: 21:00:00 EEST
-  url: https://www.meetup.com/ruby-romania/events/302016838/
+  url: https://www.meetup.com/ruby-romania/events/302016838
 
 - name: Ruby Montevideo - Meetup July 2024
   location: Montevideo, Uruguay
@@ -1198,7 +1198,7 @@
   date: 2024-07-27
   start_time: '09:30:00 -03'
   end_time: 11:30:00 -03
-  url: https://rubydf.com/events/terceira-edicao/
+  url: https://rubydf.com/events/terceira-edicao
 
 - name: WNB.rb - July 2024
   location: Online
@@ -1212,7 +1212,7 @@
   date: 2024-07-31
   start_time: 18:00:00 HKT
   end_time: 20:00:00 HKT
-  url: https://www.meetup.com/ruby-phil/events/302437676/
+  url: https://www.meetup.com/ruby-phil/events/302437676
 
 - name: SD Ruby - Meetup August 2024
   location: San Diego, CA
@@ -1261,7 +1261,7 @@
   date: 2024-08-13
   start_time: 18:30:00 CDT
   end_time: 20:30:00 CDT
-  url: https://www.meetup.com/austinrb/events/297610749/
+  url: https://www.meetup.com/austinrb/events/297610749
 
 - name: Boston Ruby Group - August 2024 meeting
   location: Boston, MA
@@ -1812,7 +1812,7 @@
   date: 2024-10-01
   start_time: 18:00:00 EDT
   end_time: 20:00:00 EDT
-  url: https://bluegrassruby.club/
+  url: https://bluegrassruby.club
 
 - name: Brighton Ruby Group - We're Back From The Dead
   location: Brighton, UK
@@ -2164,7 +2164,7 @@
   date: 2024-11-05
   start_time: 18:00:00 EDT
   end_time: 20:00:00 EDT
-  url: https://bluegrassruby.club/
+  url: https://bluegrassruby.club
 
 - name: Charlotte Ruby - Ruby Hack Night November 2024
   location: Online
@@ -2446,7 +2446,7 @@
   date: 2024-12-03
   start_time: 18:00:00 EDT
   end_time: 20:00:00 EDT
-  url: https://bluegrassruby.club/
+  url: https://bluegrassruby.club
 
 - name: Charlotte Ruby - Ruby Hack Night December 2024
   location: Online

--- a/_data/meetups.yml
+++ b/_data/meetups.yml
@@ -63,6 +63,14 @@
   end_time: 22:00:00 EST
   url: https://www.meetup.com/phillyrb/events/297923423
 
+- name: Ruby User Group Berlin - January Meetup 2024
+  location: Berlin, Germany
+  date: 2024-01-11
+  start_time: 19:00:00 CET
+  end_time: 21:00:00 CET
+  url: https://www.rug-b.de/events/canceled-january-meetup-2024-watch-the-date-canceled-768
+  status: cancelled
+
 - name: ChicagoRuby - Totally Solid Cache and Queue by Daniel Schadd
   location: Chicago, IL
   date: 2024-01-17
@@ -70,7 +78,8 @@
   end_time: 20:00:00 CST
   url: https://www.meetup.com/chicagoruby/events/298091952
 
-- name: 'Toronto Ruby - Rails and the Ruby Garbage Collector: How to Speed Up Your Rails App'
+- name: 'Toronto Ruby - Rails and the Ruby Garbage Collector: How to Speed Up Your
+    Rails App'
   location: Toronto, Canada
   date: 2024-01-24
   start_time: 18:00:00 EST
@@ -132,6 +141,13 @@
   start_time: 19:00:00 PST
   end_time: 20:30:00 PST
   url: https://www.meetup.com/sdruby/events/297372058
+
+- name: RubyDF - Fevereiro de 2024 - Segunda edição
+  location: Brasilia, Brazil
+  date: 2024-02-03
+  start_time: 10:00:00 -03
+  end_time: 12:00:00 -03
+  url: https://rubydf.com/events/segunda-edicao/
 
 - name: ChicagoRuby - Jason Swett "How to Write Meaningful Tests"
   location: Chicago, IL
@@ -364,6 +380,13 @@
   end_time: 20:00:00 EDT
   url: https://www.meetup.com/brooklyn-rb/events/299260716
 
+- name: Ruby User Group Cologne - März 2024
+  location: Cologne, Germany
+  date: 2024-03-20
+  start_time: 19:00:00 CEST
+  end_time: 21:00:00 CEST
+  url: https://www.colognerb.de/events/kolsch-rb-marz-2024-773
+
 - name: Polish Ruby User Group (PLRUG) - Meetup March 2024
   location: Warsaw, Poland
   date: 2024-03-21
@@ -482,6 +505,13 @@
   start_time: 20:30:00 EDT
   end_time: 22:00:00 EDT
   url: https://www.meetup.com/phillyrb/events/298382205
+
+- name: Ruby User Group Berlin - Elixir Crossover Birthday Event
+  location: Berlin, Germany
+  date: 2024-04-11
+  start_time: 19:00:00 CEST
+  end_time: 21:00:00 CEST
+  url: https://www.rug-b.de/events/elixir-crossover-birthday-event-check-the-date-772
 
 - name: brooklyn.rb - rails new happy_hack_hour
   location: Brooklyn, NY
@@ -938,6 +968,13 @@
   end_time: 19:30:00 EDT
   url: https://lu.ma/p53lc1vp
 
+- name: Ruby User Group Cologne - Juni 2024 Meetup
+  location: Cologne, Germany
+  date: 2024-06-20
+  start_time: 19:00:00 CEST
+  end_time: 21:00:00 CEST
+  url: https://www.colognerb.de/events/juni-2024-meetup-779
+
 - name: Ruby::AZ - Vite Ruby for your Rails app's frontend assets
   location: Chandler, AZ
   date: 2024-06-20
@@ -1007,6 +1044,14 @@
   start_time: 19:15:00 CEST
   end_time: 22:15:00 CEST
   url: https://www.meetup.com/paris_rb/events/301437243
+
+- name: Ruby User Group Berlin - July 2024 outdoor social gathering
+  location: Berlin, Germany
+  date: 2024-07-04
+  start_time: 18:30:00 CEST
+  end_time: 20:30:00 CEST
+  url: https://www.rug-b.de/events/canceled-july-2024-outdoor-social-gathering-815
+  status: cancelled
 
 - name: London Ruby User Group - July 2024 Meeting
   location: London, UK
@@ -1148,12 +1193,12 @@
   end_time: 10:00:00 CDT
   url: https://www.meetup.com/austinrb/events/300257002
 
-- name: Ruby DF - July
-  location: Brasília, Brazil
+- name: RubyDF - Julho de 2024 - Terceira edição
+  location: Brasilia, Brazil
   date: 2024-07-27
-  start_time: '09:30:00 BRT'
-  end_time: 12:00:00 BRT
-  url: https://rubydf.com/events/terceira-edicao
+  start_time: '09:30:00 -03'
+  end_time: 11:30:00 -03
+  url: https://rubydf.com/events/terceira-edicao/
 
 - name: WNB.rb - July 2024
   location: Online
@@ -1287,6 +1332,13 @@
   start_time: 18:00:00 CEST
   end_time: 21:00:00 CEST
   url: https://www.meetup.com/polishrubyusergroup/events/302785548
+
+- name: Ruby User Group Cologne - August 2024 Meetup
+  location: Cologne, Germany
+  date: 2024-08-22
+  start_time: 19:00:00 CEST
+  end_time: 21:00:00 CEST
+  url: https://www.colognerb.de/events/august-2024-meetup-782
 
 - name: 'Bangkok.rb - Ruby Tuesday #56'
   location: เขตวัฒนา, Thailand
@@ -1422,6 +1474,13 @@
   end_time: 19:00:00 CST
   url: https://www.meetup.com/rails-taiwan/events/302844480
 
+- name: Ruby User Group Berlin - September Meetup 2024
+  location: Berlin, Germany
+  date: 2024-09-05
+  start_time: 19:00:00 CEST
+  end_time: 21:00:00 CEST
+  url: https://www.rug-b.de/events/september-meetup-2024-848
+
 - name: SD Ruby - Monthly Meetup September 2024
   location: San Diego, CA
   date: 2024-09-05
@@ -1443,19 +1502,19 @@
   end_time: 13:00:00 EAT
   url: https://www.meetup.com/african_ruby_community/events/300548245
 
-- name: London Ruby User Group - September 2024 Meeting
-  location: London, UK
-  date: 2024-09-09
-  start_time: 18:00:00 BST
-  end_time: 20:00:00 BST
-  url: https://lrug.org/meetings/2024/september
-
 - name: Boston Ruby Group - Project Night September 2024
   location: Boston, MA
   date: 2024-09-09
   start_time: 18:00:00 EDT
   end_time: 20:00:00 EDT
   url: https://lu.ma/af2n3jwa
+
+- name: London Ruby User Group - September 2024 Meeting
+  location: London, UK
+  date: 2024-09-09
+  start_time: 18:00:00 BST
+  end_time: 20:00:00 BST
+  url: https://lrug.org/meetings/2024/september
 
 - name: 'Austin.rb - Visualizing Problems: From Abstract to Concrete'
   location: Austin, TX
@@ -1558,7 +1617,7 @@
 
 - name: 'African Ruby Community - Ruby Thursdays: To be determined (Zoom) September
     2024'
-  location: Nairobi, Kenya
+  location: Online
   date: 2024-09-12
   start_time: 18:00:00 EAT
   end_time: 20:00:00 EAT
@@ -1919,7 +1978,7 @@
 
 - name: 'African Ruby Community - Ruby Thursdays: To be determined (Zoom) October
     2024'
-  location: Nairobi, Kenya
+  location: Online
   date: 2024-10-10
   start_time: 18:00:00 EAT
   end_time: 20:00:00 EAT
@@ -2250,7 +2309,7 @@
 
 - name: 'African Ruby Community - Ruby Thursdays: To be determined (Zoom) November
     2024'
-  location: Nairobi, Kenya
+  location: Online
   date: 2024-11-14
   start_time: 18:00:00 EAT
   end_time: 20:00:00 EAT
@@ -2525,7 +2584,7 @@
 
 - name: 'African Ruby Community - Ruby Thursdays: To be determined (Zoom) December
     2024'
-  location: Nairobi, Kenya
+  location: Online
   date: 2024-12-12
   start_time: 18:00:00 EAT
   end_time: 20:00:00 EAT

--- a/_data/meetups.yml
+++ b/_data/meetups.yml
@@ -1,5 +1,12 @@
 ---
 
+- name: Toronto Ruby - Inaugural Edition
+  location: Toronto, Canada
+  date: 2023-11-23
+  start_time: 18:00:00 EDT
+  end_time: 20:00:00 EDT
+  url: https://toronto-ruby.com/events/1
+
 - name: Charlotte Ruby - Ruby Hack Night January 2024
   location: Online
   date: 2024-01-02
@@ -7,7 +14,7 @@
   end_time: 21:30:00 EST
   url: https://www.meetup.com/charlotte-rb/events/297725393
 
-- name: 'London Ruby User Group: January 2024 Meeting'
+- name: London Ruby User Group - January 2024 Meeting
   location: London, UK
   date: 2024-01-08
   start_time: 18:00:00 GMT
@@ -63,8 +70,7 @@
   end_time: 20:00:00 CST
   url: https://www.meetup.com/chicagoruby/events/298091952
 
-- name: 'Toronto Ruby - Rails and the Ruby Garbage Collector: How to Speed Up Your
-    Rails App'
+- name: 'Toronto Ruby - Rails and the Ruby Garbage Collector: How to Speed Up Your Rails App'
   location: Toronto, Canada
   date: 2024-01-24
   start_time: 18:00:00 EST
@@ -162,7 +168,7 @@
   end_time: 20:00:00 GMT
   url: https://www.meetup.com/ruby-in-london/events/297633001
 
-- name: 'London Ruby User Group: February 2024 Meeting'
+- name: London Ruby User Group - February 2024 Meeting
   location: London, UK
   date: 2024-02-12
   start_time: 18:00:00 GMT
@@ -288,7 +294,7 @@
   end_time: 20:30:00 PST
   url: https://www.meetup.com/sdruby/events/297372059
 
-- name: 'London Ruby User Group: March 2024 Meeting'
+- name: London Ruby User Group - March 2024 Meeting
   location: London, UK
   date: 2024-03-11
   start_time: 18:00:00 GMT
@@ -449,7 +455,7 @@
   end_time: 20:30:00 PDT
   url: https://www.meetup.com/sdruby/events/297372060
 
-- name: 'London Ruby User Group: April 2024 Meeting'
+- name: London Ruby User Group - April 2024 Meeting
   location: London, UK
   date: 2024-04-08
   start_time: 18:00:00 BST
@@ -631,7 +637,7 @@
   end_time: 20:30:00 EDT
   url: https://www.meetup.com/bostonrb/events/300022368
 
-- name: 'London Ruby User Group: May 2024 Meeting'
+- name: London Ruby User Group - May 2024 Meeting
   location: London, UK
   date: 2024-05-13
   start_time: 18:00:00 BST
@@ -701,11 +707,11 @@
   end_time: 20:30:00 EDT
   url: https://lu.ma/cbeeanbk
 
-- name: Toronto Ruby - Spring edition!
+- name: Toronto Ruby - May Edition
   location: Toronto, Canada
   date: 2024-05-22
   start_time: 18:00:00 EDT
-  end_time: 21:00:00 EDT
+  end_time: 20:00:00 EDT
   url: https://radius.to/groups/toronto-ruby/events/pkgvym5ecyuc
 
 - name: ChicagoRuby - Coffee + Code @ Swadesi Cafe
@@ -848,7 +854,7 @@
   end_time: 20:30:00 PDT
   url: https://www.meetup.com/sdruby/events/297372063
 
-- name: 'London Ruby User Group: June 2024 Meeting'
+- name: London Ruby User Group - June 2024 Meeting
   location: London, UK
   date: 2024-06-10
   start_time: 18:00:00 BST
@@ -943,7 +949,7 @@
   location: Toronto, Canada
   date: 2024-06-20
   start_time: 18:00:00 EDT
-  end_time: 21:00:00 EDT
+  end_time: 20:00:00 EDT
   url: https://radius.to/groups/toronto-ruby/events/s1tczn2usqf5
 
 - name: ChicagoRuby - Madison+ Ruby + Chicago @ Chime
@@ -1002,12 +1008,12 @@
   end_time: 22:15:00 CEST
   url: https://www.meetup.com/paris_rb/events/301437243
 
-- name: 'London Ruby User Group: July 2024 Meeting'
+- name: London Ruby User Group - July 2024 Meeting
   location: London, UK
   date: 2024-07-08
   start_time: 18:00:00 BST
   end_time: 20:00:00 BST
-  url: https://lrug.org/meetings/2024/july/
+  url: https://lrug.org/meetings/2024/july
 
 - name: Austin.rb - Modern Authentication with WebAuthn
   location: Austin, TX
@@ -1198,12 +1204,12 @@
   end_time: 22:15:00 CEST
   url: https://www.meetup.com/paris_rb/events/301437247
 
-- name: 'London Ruby User Group: August 2024 Meeting'
+- name: London Ruby User Group - August 2024 Meeting
   location: London, UK
   date: 2024-08-12
   start_time: 18:00:00 BST
   end_time: 20:00:00 BST
-  url: https://lrug.org/meetings/2024/august/
+  url: https://lrug.org/meetings/2024/august
 
 - name: Austin.rb - Ruby on AI "The magic Lego"
   location: Austin, TX
@@ -1442,8 +1448,8 @@
   date: 2024-09-09
   start_time: 18:00:00 BST
   end_time: 20:00:00 BST
-  url: https://lrug.org/meetings/2024/september/
-  
+  url: https://lrug.org/meetings/2024/september
+
 - name: Boston Ruby Group - Project Night September 2024
   location: Boston, MA
   date: 2024-09-09

--- a/_data/meetups.yml
+++ b/_data/meetups.yml
@@ -63,6 +63,13 @@
   end_time: 22:00:00 EST
   url: https://www.meetup.com/phillyrb/events/297923423
 
+- name: Ruby Usergroup Hamburg - January 2024
+  location: Hamburg, Germany
+  date: 2024-01-10
+  start_time: 19:00:00 CEST
+  end_time: 21:00:00 CEST
+  url: https://hamburg.onruby.de/events/ruby-usergroup-hamburg-january-2024-770
+
 - name: Ruby User Group Berlin - January Meetup 2024
   location: Berlin, Germany
   date: 2024-01-11
@@ -204,6 +211,13 @@
   start_time: 20:30:00 EST
   end_time: 22:00:00 EST
   url: https://www.meetup.com/phillyrb/events/298024752
+
+- name: Ruby Usergroup Hamburg - February 2024
+  location: Hamburg, Germany
+  date: 2024-02-14
+  start_time: 19:00:00 CEST
+  end_time: 21:00:00 CEST
+  url: https://hamburg.onruby.de/events/ruby-usergroup-hamburg-february-2024-774
 
 - name: brooklyn.rb - rails new happy_hack_hour
   location: Brooklyn, NY
@@ -366,6 +380,13 @@
   end_time: 22:00:00 EST
   url: https://www.meetup.com/phillyrb/events/298382203
 
+- name: Ruby Usergroup Hamburg - March 2024
+  location: Hamburg, Germany
+  date: 2024-03-13
+  start_time: 19:00:00 CEST
+  end_time: 21:00:00 CEST
+  url: https://hamburg.onruby.de/events/ruby-usergroup-hamburg-march-2024-775
+
 - name: RubySur - March 2024 - Debugging
   location: Buenos Aires, Argentina / Online
   date: 2024-03-14
@@ -506,6 +527,13 @@
   end_time: 22:00:00 EDT
   url: https://www.meetup.com/phillyrb/events/298382205
 
+- name: Ruby Usergroup Hamburg - April 2024
+  location: Hamburg, Germany
+  date: 2024-04-10
+  start_time: 19:00:00 CEST
+  end_time: 21:00:00 CEST
+  url: https://hamburg.onruby.de/events/ruby-usergroup-hamburg-april-2024-777
+
 - name: Ruby User Group Berlin - Elixir Crossover Birthday Event
   location: Berlin, Germany
   date: 2024-04-11
@@ -631,6 +659,13 @@
   start_time: 17:30:00 EDT
   end_time: 19:00:00 EDT
   url: https://www.meetup.com/nyc-rb/events/299736979
+
+- name: Ruby Usergroup Hamburg - May 2024
+  location: Hamburg, Germany
+  date: 2024-05-08
+  start_time: 19:00:00 CEST
+  end_time: 21:00:00 CEST
+  url: https://hamburg.onruby.de/events/ruby-usergroup-hamburg-may-2024-778
 
 - name: Philippine Ruby Users Group - 2024 Restart Startup launchkit edition
   location: Makati, Philippines & Online
@@ -1116,6 +1151,13 @@
   end_time: 19:00:00 EDT
   url: https://www.meetup.com/nyc-rb/events/301062985
 
+- name: Ruby Usergroup Hamburg - July 2024
+  location: Hamburg, Germany
+  date: 2024-07-10
+  start_time: 19:00:00 CEST
+  end_time: 21:00:00 CEST
+  url: https://hamburg.onruby.de/events/ruby-usergroup-hamburg-july-2024-780
+
 - name: Ruby Fusion - Milestones
   location: Online
   date: 2024-07-11
@@ -1304,6 +1346,13 @@
   start_time: 18:00:00 MDT
   end_time: 20:30:00 MDT
   url: https://lu.ma/16ykggyu
+
+- name: Ruby Usergroup Hamburg - August 2024
+  location: Hamburg, Germany
+  date: 2024-08-14
+  start_time: 19:00:00 CEST
+  end_time: 21:00:00 CEST
+  url: https://hamburg.onruby.de/events/ruby-usergroup-hamburg-august-2024-881
 
 - name: RubySur - August 2024 - Refactoring
   location: Buenos Aires, Argentina / Online
@@ -1614,6 +1663,13 @@
   start_time: 19:00:00 -03
   end_time: 22:00:00 -03
   url: https://www.meetup.com/ruby-montevideo/events/303136598
+
+- name: Ruby Usergroup Hamburg - September 2024
+  location: Hamburg, Germany
+  date: 2024-09-11
+  start_time: 21:00:00 CEST
+  end_time: 23:00:00 CEST
+  url: https://hamburg.onruby.de/events/ruby-usergroup-hamburg-september-2024-914
 
 - name: 'African Ruby Community - Ruby Thursdays: To be determined (Zoom) September
     2024'
@@ -2307,6 +2363,13 @@
   end_time: 19:00:00 CST
   url: https://www.meetup.com/rails-taiwan/events/qxfvjkygcpbrb
 
+- name: Ruby Usergroup Hamburg - November 2024
+  location: Hamburg, Germany
+  date: 2024-11-13
+  start_time: 19:00:00 CEST
+  end_time: 21:00:00 CEST
+  url: https://hamburg.onruby.de/events/ruby-usergroup-hamburg-november-2024-915
+
 - name: 'African Ruby Community - Ruby Thursdays: To be determined (Zoom) November
     2024'
   location: Online
@@ -2581,6 +2644,13 @@
   start_time: 19:00:00 CST
   end_time: 19:00:00 CST
   url: https://www.meetup.com/rails-taiwan/events/qxfvjkygcqbpb
+
+- name: Ruby Usergroup Hamburg - Chrismas Edition - Dezember 2024
+  location: Hamburg, Germany
+  date: 2024-12-11
+  start_time: 19:00:00 CEST
+  end_time: 21:00:00 CEST
+  url: https://hamburg.onruby.de/events/ruby-usergroup-hamburg-chrismas-edition-dezember-2024-916
 
 - name: 'African Ruby Community - Ruby Thursdays: To be determined (Zoom) December
     2024'

--- a/src/events/abstract_event.rb
+++ b/src/events/abstract_event.rb
@@ -35,13 +35,13 @@ class AbstractEvent
   end
 
   def event_title
-    title = event_name.gsub(group.name, "").squeeze(" ")
+    title = event_name
 
     Array(group.remove || "").each do |remove|
       title = title.gsub(remove, "")
     end
 
-    title = title.strip
+    title = title.gsub(group.name, "").squeeze(" ").strip
 
     duplicate_names = group.upcoming_events.map { |event| event.event_name }.tally.select { |key, value| value >= 2 }
 

--- a/src/events/abstract_event.rb
+++ b/src/events/abstract_event.rb
@@ -76,6 +76,14 @@ class AbstractEvent
   end
 
   def event_status
+    if event_name.downcase.include?("cancelled") || event_name.downcase.include?("canceled")
+      return "cancelled"
+    end
+
+    if event_name.downcase.include?("postponed")
+      return "postponed"
+    end
+
     nil
   end
 

--- a/src/events/abstract_event.rb
+++ b/src/events/abstract_event.rb
@@ -35,7 +35,13 @@ class AbstractEvent
   end
 
   def event_title
-    title = event_name.gsub(group.name, "").squeeze(" ").gsub(group.remove || "", "").strip
+    title = event_name.gsub(group.name, "").squeeze(" ")
+
+    Array(group.remove || "").each do |remove|
+      title = title.gsub(remove, "")
+    end
+
+    title = title.strip
 
     duplicate_names = group.upcoming_events.map { |event| event.event_name }.tally.select { |key, value| value >= 2 }
 

--- a/src/events/abstract_event.rb
+++ b/src/events/abstract_event.rb
@@ -11,6 +11,9 @@ class AbstractEvent
   def_delegators :meetup_file_entry, :name, :location, :date, :start_time, :end_time, :url
 
   def self.service_id_for_url(url)
+    return nil if url.nil?
+    return nil if url.blank?
+
     if url.start_with?("https://www.meetup.com/") || url.start_with?("https://meetup.com/")
       return url.split("/").last
     end
@@ -19,7 +22,7 @@ class AbstractEvent
       return url.split("/").last
     end
 
-    nil
+    url
   end
 
   def initialize(object:, group:)
@@ -49,7 +52,7 @@ class AbstractEvent
     @meetup_file_entry ||= MeetupsFileEntry.new(
       name: event_title,
       location: event_location,
-      date: event_start_time.iso8601,
+      date: event_date.iso8601,
       start_time: [event_start_time.strftime("%H:%M:%S"), tz.now.strftime("%Z")].join(" "),
       end_time: [event_end_time.strftime("%H:%M:%S"), tz.now.strftime("%Z")].join(" "),
       url: event_url,

--- a/src/events/abstract_event.rb
+++ b/src/events/abstract_event.rb
@@ -61,7 +61,7 @@ class AbstractEvent
       date: event_date.iso8601,
       start_time: [event_start_time.strftime("%H:%M:%S"), tz.now.strftime("%Z")].join(" "),
       end_time: [event_end_time.strftime("%H:%M:%S"), tz.now.strftime("%Z")].join(" "),
-      url: event_url,
+      url: event_url.gsub(/\/$/, ""),
       group: group,
       status: event_status
     )

--- a/src/events/ical_event.rb
+++ b/src/events/ical_event.rb
@@ -4,7 +4,9 @@ class IcalEvent < AbstractEvent
   def event_location
     location = object.location.to_s
 
-    return "Online" if location.start_with?("https://")
+    return "Online" if location.start_with?("https://") || location == "Online" || location == "Virtual" || event_name.include?("Virtual") || event_name.include?("Zoom")
+
+    return group.default_location if group.default_location
 
     location
   end
@@ -14,7 +16,7 @@ class IcalEvent < AbstractEvent
   end
 
   def event_name
-    object.summary
+    object.summary.force_encoding("utf-8")
   end
 
   def event_start_time

--- a/src/events/ical_event.rb
+++ b/src/events/ical_event.rb
@@ -1,0 +1,31 @@
+require_relative "./abstract_event"
+
+class IcalEvent < AbstractEvent
+  def event_location
+    location = object.location.to_s
+
+    return "Online" if location.start_with?("https://")
+
+    location
+  end
+
+  def service_id
+    event_url || object.uid
+  end
+
+  def event_name
+    object.summary
+  end
+
+  def event_start_time
+    tz.to_local(object.dtstart)
+  end
+
+  def event_end_time
+    tz.to_local(object.dtend)
+  end
+
+  def event_url
+    object.url.to_s
+  end
+end

--- a/src/events/meetup_event.rb
+++ b/src/events/meetup_event.rb
@@ -30,7 +30,7 @@ class MeetupEvent < AbstractEvent
 
     country = ISO3166::Country.new(country_raw)
 
-    if object.isOnline
+    if object.isOnline || event_name.include?("Virtual") || event_name.include?("Zoom")
       "Online"
     elsif country.alpha2 == "US"
       "#{city}, #{state.upcase}"

--- a/src/meetups_file.rb
+++ b/src/meetups_file.rb
@@ -52,7 +52,7 @@ class MeetupsFile
     end
 
     group.upcoming_events.map { |event| event.meetup_file_entry }.each do |event|
-      event_entry = find_by(url: event.url)
+      event_entry = find_by(service_id: event.service_id)
 
       if event_entry && event != event_entry
         @updated_events << event

--- a/src/meetups_file.rb
+++ b/src/meetups_file.rb
@@ -175,6 +175,6 @@ class MeetupsFile
   end
 
   def write!
-    PATH.write(@events.sort_by { |event| [event.date, event.name] }.map(&:to_hash).to_yaml.gsub("- name:", "\n- name:"))
+    PATH.write(@events.uniq.sort_by { |event| [event.date, event.name] }.map(&:to_hash).to_yaml.gsub("- name:", "\n- name:"))
   end
 end

--- a/src/static/meetup.rb
+++ b/src/static/meetup.rb
@@ -6,6 +6,8 @@ class Meetup < FrozenRecord::Base
       Meetup.all.select { |meetup| meetup.url.include?(group.id) }
     elsif group.luma?
       Meetup.all.select { |meetup| meetup.name.include?(group.name) }
+    elsif group.ical?
+      Meetup.all.select { |meetup| meetup.name.include?(group.name) }
     else
       raise "Unsupported service: #{group.service}"
     end


### PR DESCRIPTION
This pull request adds a way to automatically fetch meetups from any ical calendar. The main motivation is to automatically fetch and import meetups from:
* https://toronto-ruby.com
* https://seattlerb.org
* https://lrug.org
* https://rubydf.com
* and possibly more

