### PR TITLE
Fixed Ruby Fusion identifiers

### DIFF
--- a/_data/meetup_groups.yml
+++ b/_data/meetup_groups.yml
@@ -564,7 +564,7 @@
 #   name:
 #   service: meetupdotcom
 
-- id: ruby-fusion
+- id: ruby_fusion
   name: Ruby Fusion
   service: luma
   ical_url: https://api.lu.ma/ics/get?entity=calendar&id=cal-HxTn4dLUlMlzEQX

--- a/_data/meetups.yml
+++ b/_data/meetups.yml
@@ -608,7 +608,7 @@
   date: 2024-05-09
   start_time: 19:00:00 MDT
   end_time: 20:30:00 MDT
-  url: https://lu.ma/ruby_fusion
+  url: https://lu.ma/ruby_fusion-inception
 
 - name: Ruby Montevideo - Meetup May 2024
   location: Montevideo, Uruguay
@@ -825,7 +825,7 @@
   date: 2024-06-06
   start_time: 18:30:00 MDT
   end_time: 20:30:00 MDT
-  url: https://lu.ma/ruby_fusion
+  url: https://lu.ma/evt-gZUrAREsvN62jAm
 
 - name: Ruby Montevideo - Meetup June 2024
   location: Montevideo, Uruguay
@@ -1070,7 +1070,7 @@
   date: 2024-07-11
   start_time: 18:30:00 MDT
   end_time: 20:30:00 MDT
-  url: https://lu.ma/ruby_fusion
+  url: https://lu.ma/oyzfeg7u
 
 - name: 'Ruby Romania Meetup #05'
   location: Bucharest, Romania

--- a/_data/meetups.yml
+++ b/_data/meetups.yml
@@ -608,7 +608,7 @@
   date: 2024-05-09
   start_time: 19:00:00 MDT
   end_time: 20:30:00 MDT
-  url: https://lu.ma/ruby_fusion-inception
+  url: https://lu.ma/ruby_fusion
 
 - name: Ruby Montevideo - Meetup May 2024
   location: Montevideo, Uruguay
@@ -1070,7 +1070,7 @@
   date: 2024-07-11
   start_time: 18:30:00 MDT
   end_time: 20:30:00 MDT
-  url: https://lu.ma/oyzfeg7u
+  url: https://lu.ma/ruby_fusion
 
 - name: 'Ruby Romania Meetup #05'
   location: Bucharest, Romania


### PR DESCRIPTION
## Overview

Necessary update to the correct ID which is `ruby_fusion`, not `ruby-fusion`. The underscore is important.

## Details

⚠️ Due to the ID being updated, I'm not sure if this effects the `ical_url`. I don't have an API key, at the moment, so don't have a quick way to confirm if the iCal URL needs updating as well.