### PR TITLE
Feat/meetup page filter

### DIFF
--- a/_includes/meetup.html
+++ b/_includes/meetup.html
@@ -1,14 +1,16 @@
-<dt>
-  {% if meetup.url %}
-    <a href="{{ meetup.url }}">{{ meetup.name }}</a>
-  {% else %}
-    <a>{{ meetup.name }}</a>
-  {% endif %}
-</dt>
-
-<dd>
-  <ul>
-    <li>{{ meetup.date | date: "%B %-d, %Y" }}</li>
-    <li>{{ meetup.location }}</li>
-  </ul>
-</dd>
+<div class="meetup-item {{ meetup.date | date: '%Y%m' }}">
+  <dt>
+    {% if meetup.url %}
+      <a href="{{ meetup.url }}">{{ meetup.name }}</a>
+    {% else %}
+      <a>{{ meetup.name }}</a>
+    {% endif %}
+  </dt>
+  
+  <dd>
+    <ul>
+      <li>{{ meetup.date | date: "%B %-d, %Y" }}</li>
+      <li>{{ meetup.location }}</li>
+    </ul>
+  </dd>  
+</div>

--- a/_includes/meetup.html
+++ b/_includes/meetup.html
@@ -10,8 +10,5 @@
   <ul>
     <li>{{ meetup.date | date: "%B %-d, %Y" }}</li>
     <li>{{ meetup.location }}</li>
-    {% if meetup.url %}
-      <li><a href="{{ meetup.url }}">Website</a></li>
-    {% endif %}
   </ul>
 </dd>

--- a/_includes/meetup_dates_filter.html
+++ b/_includes/meetup_dates_filter.html
@@ -1,0 +1,80 @@
+<div class="meetup-dates-container">
+  {% assign unique_dates = "" | split: "" %}
+  {% assign now = "now" | date: "%Y-%m-%d 00:00:00" | date: "%s" | plus: 0 %}
+  {% for meetup in meetups %}
+    {% assign date = meetup.date | date: "%s" | plus: 0 %}
+    {% if date >= now %}
+      {% assign formatted_date = meetup.date | date: "%Y%m" %}
+      {% unless unique_dates contains formatted_date %}
+        <div class="meetup-date-clip"
+             title="{{ meetup.date | date: '%B %Y' }}"
+             onclick="toggleByYearMonth(`{{ meetup.date | date: '%Y%m' }}`, this)">
+          {{ meetup.date | date: "%B %Y" }}
+        </div>
+        {% assign unique_dates = unique_dates | push: formatted_date %}
+      {% endunless %}
+    {% endif %}
+  {% endfor %}
+</div>
+
+<script>
+  function toggleByYearMonth(yearMonthToShow, element) {
+    const isElementSelected = element.classList.contains('selected');
+    if (isElementSelected) {
+      showAllMeetups();
+      element.classList.remove('selected');
+    } else {
+      showMeetups(yearMonthToShow);
+
+      const clips = document.querySelectorAll('.meetup-date-clip');
+      clips.forEach(clip => clip.classList.remove('selected'));
+      element.classList.add('selected');
+    } 
+  }
+
+  function showAllMeetups() {
+    const meetups = document.getElementsByClassName('meetup-item');
+    Array.from(meetups).forEach(meetup => {
+      meetup.style.display = 'block';
+    });
+  }
+
+  function showMeetups(yearMonth) {
+    const meetups = document.getElementsByClassName('meetup-item');
+    Array.from(meetups).forEach(meetup => {
+      if (meetup.classList.contains(yearMonth)) {
+        meetup.style.display = 'block';
+      } else {
+        meetup.style.display = 'none';
+      }
+    });
+  }
+</script>
+
+<style>
+  .meetup-dates-container {
+    display: flex;
+    gap: 12px;
+    margin-bottom: 24px;
+    overflow-x: auto;
+    white-space: nowrap;
+    &::-webkit-scrollbar {
+      display: none;
+    }
+  }
+
+  .meetup-date-clip {
+    background-color: white;
+    padding: 4px 16px;
+    border-radius: 24px;
+    white-space: nowrap;
+    &:hover {
+      background-color: #f0f0f0;
+      cursor: pointer;
+    }
+    &.selected {
+      background-color: #c72c41;
+      color: white;
+    }
+  }
+</style>

--- a/_includes/meetup_dates_filter.html
+++ b/_includes/meetup_dates_filter.html
@@ -64,6 +64,7 @@
   }
 
   .meetup-date-clip {
+    color: #444;
     background-color: white;
     padding: 4px 16px;
     border-radius: 24px;

--- a/_includes/meetup_dates_filter.html
+++ b/_includes/meetup_dates_filter.html
@@ -54,13 +54,10 @@
 <style>
   .meetup-dates-container {
     display: flex;
+    flex-wrap: wrap;
     gap: 12px;
     margin-bottom: 24px;
-    overflow-x: auto;
     white-space: nowrap;
-    &::-webkit-scrollbar {
-      display: none;
-    }
   }
 
   .meetup-date-clip {

--- a/meetups/index.html
+++ b/meetups/index.html
@@ -5,6 +5,7 @@ layout: default
   <dl>
     {% assign now = "now" | date: "%Y-%m-%d 00:00:00" | date: "%s" | plus: 0 %}
     {% assign meetups = site.data.meetups | sort: "date" %}
+    {% include meetup_dates_filter.html %}
     {% for meetup in meetups %}
       {% assign date = meetup.date | date: "%s" | plus: 0 %}
       {% if date >= now %}


### PR DESCRIPTION
closes https://github.com/ruby-conferences/ruby-conferences.github.io/issues/632

## major change - adding a filter by YYYY-MM 
- Implemented a filter by year and month using raw JavaScript (no new dependencies).
- Used an onclick method to show/hide relevant meetups.
- Note: The UI isn't perfect, but it's a functional and quick fix.

### other considerations
- Didn't add a location filter:
  - It would require adding more data for each meetup, which is cumbersome.
  - Users likely go directly to meetup.com if searching by country/state. We can revisit this in a future PR if needed.

## other minor UI improvements
- Removed redundant "website" text to declutter the UI.

## demo
https://github.com/user-attachments/assets/75005fd4-0e7f-41d6-b310-a63429760f6b
