### PR TITLE
Detect duplicate meetup events in `DataFileValidator`

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -71,6 +71,7 @@ task :verify_meetups do
   events = validator.events
   dates = events.map { |event| event["start_date"] }
   exit 5 unless dates.sort == dates
+  exit 6 if validator.duplicate_events?
 end
 
 task :fetch_meetups do

--- a/_data/meetups.yml
+++ b/_data/meetups.yml
@@ -1554,21 +1554,7 @@
   date: 2024-09-16
   start_time: 18:00:00 EDT
   end_time: 20:00:00 EDT
-  url: https://www.meetup.com/columbusrb/events/xwwkltygcmbvb
-
-- name: Columbus Ruby Brigade - Monthly Meetup September 2024
-  location: Columbus, OH
-  date: 2024-09-16
-  start_time: 18:00:00 EDT
-  end_time: 20:00:00 EDT
   url: https://www.meetup.com/columbusrb/events/303084093
-
-- name: Miami Ruby Brigade - September 2024
-  location: Coral Gables, FL
-  date: 2024-09-16
-  start_time: 19:00:00 EDT
-  end_time: 21:00:00 EDT
-  url: https://www.meetup.com/miamirb/events/pdvctsygcmbvb
 
 - name: Miami Ruby Brigade - September 2024
   location: Coral Gables, FL

--- a/src/data_file_validator.rb
+++ b/src/data_file_validator.rb
@@ -27,6 +27,17 @@ class DataFileValidator
         @bonus_keys_error = true
       end
     end
+
+    if @type == :meetup
+      event_groups_by_date = events.map { |event| [event["name"].split(" - ").first, event["date"]] }
+
+      duplicate_events = event_groups_by_date.tally.select { |group, count| count > 1 }
+
+      duplicate_events.each do |(group, date), _count|
+        @duplicate_events_error = true
+        puts "Meetup Group '#{group}' has two events on #{date.iso8601}"
+      end
+    end
   end
 
   def missing_keys?
@@ -35,6 +46,10 @@ class DataFileValidator
 
   def bonus_keys?
     @bonus_keys_error
+  end
+
+  def duplicate_events?
+    @duplicate_events_error
   end
 
   private

--- a/src/data_file_validator.rb
+++ b/src/data_file_validator.rb
@@ -33,9 +33,9 @@ class DataFileValidator
 
       duplicate_events = event_groups_by_date.tally.select { |group, count| count > 1 }
 
-      duplicate_events.each do |(group, date), _count|
+      duplicate_events.each do |(group, date), count|
         @duplicate_events_error = true
-        puts "Meetup Group '#{group}' has two events on #{date.iso8601}"
+        puts "Meetup Group '#{group}' has #{count} events on #{date.iso8601}"
       end
     end
   end


### PR DESCRIPTION
Meetup.com is somehow switching back and forth between Integer IDs and some obfuscated IDs for their events. Because of that we aren't able to match the event to an existing event.

But, we can check if there are two events from the same group on the same day. Now the `rake verify_meetups` rake tasks fails when it detects that a groups has two events on a single day.

There might be use-cases where a group has two events one a day, but it seems very unlikely, which is why we are leaving that out for now.