### PR TITLE
Automatically remove meetups or mark them as cancelled

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Extra keys for the upcoming events:
 * `cfp_open_date`: The date when the CFP was opened - ISO8601 formatted (yyyy-mm-dd).
 * `cfp_close_date`: If there is a CFP deadline, enter that here - ISO8601 formatted (yyyy-mm-dd).
 * `cfp_link`: A link to the CFP submission page.
-* `status`:  Typically you want to put "Canceled", "Postponed" or "To be announced" here.
+* `status`:  Typically you want to put "Cancelled", "Postponed" or "To be announced" here.
 * `date_precision`: Controls the precision of the `start_date` and `end_date` when the conference dates aren't announced just yet but it's confirmed that the conference is happening. Possible values: `full` (implicit default), `month` or `year`. The `start_date` and `end_date` fields still need to be fully formatted ISO8601 dates, you can put the last day of the month/year in it so it also gets ordered properly.
 * `announced_on`: The date on which the conference was announced - ISO8601 formatted (yyyy-mm-dd). This date is used as the publish date for the [RSS feed](https://rubyconferences.org/feed.xml) so people can stay up to date with newly announced conferences.
 
@@ -87,6 +87,7 @@ Here is a list of the keys that can be used:
   * ZZZ - timezone (e.g. CDT or EST)
 * `end_time`: The end time of the event - ISO8601 formatted as (hh:mm:ss ZZZ) using same values as `start_time`
 * `url`: The url for the event.
+* `status`:  Typically you want to put "Cancelled" or "Postponed" here.
 
 ## Getting started
 

--- a/Rakefile
+++ b/Rakefile
@@ -60,7 +60,8 @@ task :verify_meetups do
     "url",
     "twitter",
     "mastodon",
-    "video_link"
+    "video_link",
+    "status"
   ]
   data = YAML.load_file("_data/meetups.yml", permitted_classes: [Date])
   validator = DataFileValidator.validate(data, allowed_keys, :meetup)

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1876,7 +1876,7 @@
   end_date: 2020-03-22
   url: https://2020.wrocloverb.com
   twitter: wrocloverb
-  status: Canceled
+  status: Cancelled
 
 - name: Ruby Retreat NZ 2020
   location: Mt Cheeseman, near Christchurch, New Zealand
@@ -1884,7 +1884,7 @@
   start_date: 2020-03-27
   end_date: 2020-03-30
   twitter: RubyNewZealand
-  status: Canceled
+  status: Cancelled
 
 - name: Ruby by the Bay (Ruby for Good)
   location: Sausalito, CA
@@ -1906,7 +1906,7 @@
   end_date: 2020-04-26
   url: https://rubyconfindia.org
   twitter: rubyconfindia
-  status: Canceled
+  status: Cancelled
 
 - name: RailsConf 2020.2 Couch Edition
   location: Your Couch
@@ -1922,7 +1922,7 @@
   end_date: 2020-05-16
   url: https://balkanruby.com
   twitter: balkanruby
-  status: Canceled
+  status: Cancelled
 
 - name: Pivorak Conf. 5.0
   location: Online
@@ -1938,7 +1938,7 @@
   end_date: 2020-06-07
   url: https://2020.rubyunconf.eu/
   twitter: rubyunconfeu
-  status: Canceled
+  status: Cancelled
 
 - name: Saint P Rubyconf 2020
   location: Saint Petersburg, Russia
@@ -1946,7 +1946,7 @@
   end_date: 2020-06-07
   url: https://spbrubyconf.ru/
   twitter: saintpruby
-  status: Canceled
+  status: Cancelled
 
 - name: Brighton Ruby 2020
   location: Online
@@ -1962,7 +1962,7 @@
   end_date: 2020-07-17
   url: https://rubyness.org/
   twitter: rubynessconf
-  status: Canceled
+  status: Cancelled
 
 - name: RubyConfBY
   location: Online
@@ -1994,7 +1994,7 @@
   end_date: 2020-09-13
   url: https://rubyc.eu/
   twitter: rubyc_eu
-  status: Canceled
+  status: Cancelled
 
 - name: RubyDay
   location: Online
@@ -2027,7 +2027,7 @@
   end_date: 2020-10-17
   url: https://rubyconfth.com/
   twitter: rubyconfth
-  status: Canceled
+  status: Cancelled
 
 - name: ROSS conf
   location: Online
@@ -2681,7 +2681,7 @@
   url: https://west.railscamp.us/2024
   twitter: railscamp_usa
   announced_on: 2024-02-29
-  status: Canceled
+  status: Cancelled
 
 - name: Fukuoka RubyistKaigi 04
   location: Fukuoka, Japan
@@ -2753,7 +2753,7 @@
   cfp_open_date: 2023-12-05
   cfp_close_date: 2024-08-10
   cfp_link: https://www.papercall.io/rubyfuza-2024
-  status: Canceled
+  status: Cancelled
   announced_on: 2023-10-18
 
 - name: Ruby Retreat 2024

--- a/_data/meetups.yml
+++ b/_data/meetups.yml
@@ -1344,6 +1344,7 @@
   start_time: 11:00:00 IST
   end_time: 13:00:00 IST
   url: https://www.meetup.com/punerubymeetup/events/302884102
+  status: cancelled
 
 - name: Orange County Ruby Users Group - Ruby Science September 2024
   location: Online
@@ -1456,6 +1457,7 @@
   start_time: 19:00:00 EDT
   end_time: 21:00:00 EDT
   url: https://www.meetup.com/bmore-on-rails/events/302969766
+  status: cancelled
 
 - name: Philly.rb - Pubnite September 2024
   location: Online
@@ -1836,7 +1838,8 @@
   date: 2024-10-08
   start_time: 19:00:00 EDT
   end_time: 21:00:00 EDT
-  url: https://www.meetup.com/bmore-on-rails/events/rkzbjsygcnblb
+  url: https://www.meetup.com/bmore-on-rails/events/303140069
+  status: cancelled
 
 - name: Philly.rb - Pubnite October 2024
   location: Online
@@ -2166,7 +2169,8 @@
   date: 2024-11-12
   start_time: 19:00:00 EDT
   end_time: 21:00:00 EDT
-  url: https://www.meetup.com/bmore-on-rails/events/rkzbjsygcpbqb
+  url: https://www.meetup.com/bmore-on-rails/events/303140100
+  status: cancelled
 
 - name: Philly.rb - Pubnite November 2024
   location: Online
@@ -2447,7 +2451,8 @@
   date: 2024-12-10
   start_time: 19:00:00 EDT
   end_time: 21:00:00 EDT
-  url: https://www.meetup.com/bmore-on-rails/events/rkzbjsygcqbnb
+  url: https://www.meetup.com/bmore-on-rails/events/303140116
+  status: cancelled
 
 - name: Philly.rb - Pubnite December 2024
   location: Online

--- a/_includes/meetup.html
+++ b/_includes/meetup.html
@@ -4,6 +4,10 @@
   {% else %}
     <a>{{ meetup.name }}</a>
   {% endif %}
+
+  {% if meetup.status %}
+    <div class="status" data-phrase="{{ meetup.status }}"></div>
+  {% endif %}
 </dt>
 
 <dd>

--- a/src/events/abstract_event.rb
+++ b/src/events/abstract_event.rb
@@ -54,6 +54,7 @@ class AbstractEvent
       end_time: [event_end_time.strftime("%H:%M:%S"), tz.now.strftime("%Z")].join(" "),
       url: event_url,
       group: group,
+      status: event_status
     )
   end
 
@@ -63,6 +64,10 @@ class AbstractEvent
 
   def event_date
     event_start_time.to_date
+  end
+
+  def event_status
+    nil
   end
 
   def event_name

--- a/src/events/meetup_event.rb
+++ b/src/events/meetup_event.rb
@@ -19,6 +19,10 @@ class MeetupEvent < AbstractEvent
     object.eventUrl
   end
 
+  def event_status
+    object.status == "published" ? nil : object.status
+  end
+
   def event_location
     city = object.dig("venue", "city") || object.dig("group", "city")
     state = object.dig("venue", "state") || object.dig("group", "state")

--- a/src/meetup_graphql_schema.json
+++ b/src/meetup_graphql_schema.json
@@ -83,7 +83,7 @@
               "args": []
             },
             {
-              "name": "unifiedEvents",
+              "name": "upcomingEvents",
               "type": {
                 "kind": "OBJECT",
                 "name": "EventConnection"
@@ -94,6 +94,20 @@
                   "type": {
                     "kind": "ENUM",
                     "name": "SortOrder"
+                  }
+                },
+                {
+                  "name": "input",
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "ConnectionInput"
+                  }
+                },
+                {
+                  "name": "filter",
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "GroupUpcomingEventsFilter"
                   }
                 }
               ]
@@ -158,6 +172,34 @@
                   "kind": "OBJECT",
                   "name": "EventEdge"
                 }
+              },
+              "args": []
+            }
+          ]
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "GroupUpcomingEventsFilter",
+          "inputFields": [
+            {
+              "name": "includeCancelled",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean"
+              },
+              "args": []
+            }
+          ]
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "ConnectionInput",
+          "inputFields": [
+            {
+              "name": "first",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int"
               },
               "args": []
             }

--- a/src/meetups_file_entry.rb
+++ b/src/meetups_file_entry.rb
@@ -1,11 +1,10 @@
-MeetupsFileEntry = Data.define(:name, :location, :date, :start_time, :end_time, :url) do
+MeetupsFileEntry = Data.define(:name, :location, :date, :start_time, :end_time, :url, :status) do
   attr_reader :group
 
-  def initialize(name:, location:, date:, start_time:, end_time:, url:, group: nil)
+  def initialize(name:, location:, date:, start_time:, end_time:, url:, status: nil, group: nil)
     date = date.is_a?(Date) ? date : Date.parse(date)
     @group = group
-
-    super(name:, location:, date:, start_time:, end_time:, url:)
+    super(name:, location:, date:, start_time:, end_time:, url:, status:)
   end
 
   def self.from_yaml_item(hash)
@@ -16,7 +15,8 @@ MeetupsFileEntry = Data.define(:name, :location, :date, :start_time, :end_time, 
       start_time: hash["start_time"],
       end_time: hash["end_time"],
       url: hash["url"],
-      group: hash["group"]
+      group: hash["group"],
+      status: hash["status"]
     )
   end
 
@@ -25,7 +25,7 @@ MeetupsFileEntry = Data.define(:name, :location, :date, :start_time, :end_time, 
   end
 
   def to_hash
-    {
+    hash = {
       "name" => name,
       "location" => location,
       "date" => date,
@@ -33,6 +33,10 @@ MeetupsFileEntry = Data.define(:name, :location, :date, :start_time, :end_time, 
       "end_time" => end_time,
       "url" => url,
     }
+
+    hash["status"] = status if status.present?
+
+    hash
   end
 
   def to_md

--- a/src/queries/events_query.rb
+++ b/src/queries/events_query.rb
@@ -14,7 +14,7 @@ EventsQuery = MeetupClient::Client.parse(<<-GRAPHQL
       country
       state
       city
-      unifiedEvents(sortOrder: ASC) {
+      upcomingEvents(input: { first: 50 }, filter: { includeCancelled: true }, sortOrder: ASC) {
         count
         edges {
           cursor


### PR DESCRIPTION
This pull request removes upcoming events that cannot be found anymore or marks them as cancelled if they are marked as cancelled on meetup.com.

Additionally, we show the status as a `phrase` on the meetups page:

![CleanShot 2024-08-31 at 04 15 01](https://github.com/user-attachments/assets/ea06b9ae-0cb7-4d99-ab19-86e913bcb112)
