### PR TITLE
Enable Toronto Ruby ical

### DIFF
--- a/_data/meetup_groups.yml
+++ b/_data/meetup_groups.yml
@@ -984,11 +984,11 @@
   name: Toronto Ruby
   service: meetupdotcom
 
-# - id: toronto-ruby
-#   name: Toronto Ruby
-#   service: ical
-#   timezone: America/Toronto
-#   ical_url: https://toronto-ruby.com/events/all.ics
+- id: toronto-ruby
+  name: Toronto Ruby
+  service: ical
+  timezone: America/Toronto
+  ical_url: https://toronto-ruby.com/events/all.ics
 
 - id: toulouse-ruby-friends
   name: Toulouse.rb


### PR DESCRIPTION
Toronto Ruby now has the ical deployed through https://github.com/toronto-ruby/toronto-ruby.com/pull/42. This pull request enables the group for fetching.