### PR TITLE
Enable ical service for London Ruby User Group

### DIFF
--- a/_data/meetup_groups.yml
+++ b/_data/meetup_groups.yml
@@ -335,11 +335,11 @@
   name: London Learn Ruby
   service: meetupdotcom
 
-# - id: london-ruby-user-group
-#   name: London Ruby User Group
-#   service: ical
-#   ical_url: https://lrug.org/meeting-calendar
-#   timezone: Europe/London
+- id: london-ruby-user-group
+  name: London Ruby User Group
+  service: ical
+  ical_url: https://lrug.org/meetings.ics
+  timezone: Europe/London
 
 - id: lyonrb
   name: Lyon.rb


### PR DESCRIPTION
As of https://github.com/lrug/lrug.org/commit/3ec2d10a2c8bb5aebca2e7aa8664145764be80b9 /meetings.ics should be usable