### PR TITLE
Remove RubyRussia 2024

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -2731,13 +2731,6 @@
   cfp_link: https://docs.google.com/forms/d/e/1FAIpQLSdTKiwbhAo4leeOl-HPIG2gFVzvmWjEtBFV6mC4ueY2Gso44g/viewform
   announced_on: 2023-11-30
 
-- name: RubyRussia 2024
-  location: Moscow, Russia
-  start_date: 2024-10-02
-  end_date: 2024-10-02
-  url: https://rubyrussia.club/
-  twitter: railsclub_ru
-
 - name: Matsue RubyKaigi 11
   location: Matsue, Japan
   start_date: 2024-10-05


### PR DESCRIPTION
I’m proposing the removal of RubyRussia from this list for two reasons:

First, encouraging people to bring commerce to Russia via ticket sales, hotel bookings, restaurants, etc. when attending this conference is unethical. These payments are taxed by Russia and directly fund Russia’s war crimes in Ukraine.

Secondly, visiting Russia puts individuals at great risk, especially if they have ever posted anything online in support of Ukraine or donated to charities that help Ukraine. See https://www.theguardian.com/world/article/2024/aug/15/russian-court-jails-us-russian-woman-for-12-years-over-50-charity-donation

Note: this reverts a change that was introduced in #765.