### PR TITLE
Add validation for `announced_on` date for conferences

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -48,6 +48,7 @@ task :verify_conferences do
   events = validator.events
   dates = events.map { |event| event["start_date"] }
   exit 5 unless dates.sort == dates
+  exit 6 if validator.missing_announced_on_date?
 end
 
 task :verify_meetups do

--- a/src/data_file_validator.rb
+++ b/src/data_file_validator.rb
@@ -12,6 +12,8 @@ class DataFileValidator
   end
 
   def validate
+    requires_announced_on_after = Date.parse("2024-08-01")
+
     events.each do |event|
       missing_keys = required_keys - event.keys
       unless missing_keys.empty?
@@ -25,6 +27,12 @@ class DataFileValidator
         puts "Bonus keys: #{bonus_keys}"
         puts event
         @bonus_keys_error = true
+      end
+
+      if @type == :conference && event["start_date"].after?(requires_announced_on_after) && !event.key?("announced_on")
+        @missing_announced_on_date_error = true
+
+        puts "Conference '#{event["name"]}' doesn't have an 'announced_on' key."
       end
     end
 
@@ -50,6 +58,10 @@ class DataFileValidator
 
   def duplicate_events?
     @duplicate_events_error
+  end
+
+  def missing_announced_on_date?
+    @missing_announced_on_date_error
   end
 
   private


### PR DESCRIPTION
This pull request introduces a new validation rule for conferences, ensuring they include an `announced_on` date so we can make sure these conferences get into the RSS feed.