### PR TITLE
Add Rocky Mountain Ruby 2025

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -2895,3 +2895,14 @@
   url: https://rubyonrails.org/world/
   twitter: rails
   announced_on: 2024-09-27
+
+- name: Rocky Mountain Ruby 2025
+  location: Boulder, CO
+  # TODO: update when dates are confirmed
+  start_date: 2025-12-31
+  end_date: 2025-12-31
+  date_precision: year
+  url: https://rockymtnruby.dev
+  twitter: rmrubyconf
+  mastodon: https://ruby.social/@rockymtnruby
+  announced_on: 2024-10-08


### PR DESCRIPTION
They announced on the last day of the conference that there is going to be an edition next year, but no details yet.