### PR TITLE
Add the RubyWellington group

### DIFF
--- a/_data/meetup_groups.yml
+++ b/_data/meetup_groups.yml
@@ -1059,6 +1059,10 @@
   name: WellingtonRuby
   service: meetupdotcom
 
+- id: rubywellington
+  name: Ruby Wellington
+  service: meetupdotcom
+
 - id: west-midlands-ruby-user-group-wmrug
   name: West Midlands Ruby User Group
   service: meetupdotcom


### PR DESCRIPTION
I'm an organiser of the Ruby Wellington group - https://www.meetup.com/rubywellington/

We noticed we weren't in the meetup list so this PR adds us in.
I confirmed that when I run the `fetch_meetups` rake task it successfully picked up our next meetup, so this should be added automatically with the next automated meetup fetch run.