### PR TITLE
Add Dresden.rb meetup group

### DIFF
--- a/_data/meetup_groups.yml
+++ b/_data/meetup_groups.yml
@@ -757,6 +757,13 @@
   default_location: Leipzig, Germany
   ical_url: https://leipzig.onruby.de/events.ics
 
+- id: ruby-user-group-dresden
+  name: Dresden.rb
+  service: ical
+  timezone: Europe/Berlin
+  default_location: Dresden, Germany
+  ical_url: https://dresdenrb.onruby.de/events.ics
+
 # - id: ruby-user-group-saarland
 #   name:
 #   service: meetupdotcom


### PR DESCRIPTION
I'm not sure if it's still required to add individual meetups into the `_data/meetups.yml` file as the README suggests. As far as I understand those are automatically added by fetching data from the meetup groups file, right?