### PR TITLE
Update Helvetic Ruby 2025 dates

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -2928,6 +2928,8 @@
   url: https://helvetic-ruby.ch
   twitter: helvetic_ruby
   mastodon: https://ruby.social/@helvetic_ruby
+  cfp_open_date: 2024-12-09
+  cfp_close_date: 2025-01-29
   cfp_link: https://helvetic-ruby.ch/call-for-speakers
   announced_on: 2024-05-17
 

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -2923,7 +2923,7 @@
 
 - name: Helvetic Ruby 2025
   location: Geneva, Switzerland
-  start_date: 2025-05-23
+  start_date: 2025-05-22
   end_date: 2025-05-23
   url: https://helvetic-ruby.ch
   twitter: helvetic_ruby


### PR DESCRIPTION
Adds the CFP dates.

Also updates the conference start date for increased visibility of the community day (day 1).