### PR TITLE
add RubyConf Thailand in Bangkok 2026-01-31 to 2026-02-01 to conferences page

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -3055,3 +3055,12 @@
   twitter: rmrubyconf
   mastodon: https://ruby.social/@rockymtnruby
   announced_on: 2024-10-08
+
+- name: RubyConf Thailand
+  location: Bangkok, Thailand
+  start_date: 2026-01-31
+  end_date: 2026-02-01
+  date_precision: year
+  url: https://rubyconfth.com
+  twitter: rubyconfth
+  announced_on: 2025-02-28


### PR DESCRIPTION
add RubyConf Thailand in Bangkok 2026-01-31 to 2026-02-01 to conferences page