### PR TITLE
Fix RubyConf Austria 2026 information

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -3089,5 +3089,5 @@
   start_date: 2026-05-29
   end_date: 2026-05-31
   date_precision: year
-  url:
+  url: https://rubyconf.at
   announced_on: 2025-03-12

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -3075,15 +3075,6 @@
   mastodon: https://ruby.social/@rockymtnruby
   announced_on: 2024-10-08
 
-- name: RubyConf Austria 2025
-  location: Austria
-  # TODO: update when dates are confirmed
-  start_date: 2025-12-31
-  end_date: 2025-12-31
-  date_precision: year
-  url: https://rubyconf.at
-  announced_on: 2025-03-12
-
 - name: RubyConf TH 2026
   location: Bangkok, Thailand
   start_date: 2026-01-31
@@ -3091,3 +3082,12 @@
   url: https://rubyconfth.com
   twitter: rubyconfth
   announced_on: 2025-02-28
+
+- name: RubyConf Austria 2026
+  location: Vienna, Austria
+  # TODO: update when dates are confirmed
+  start_date: 2026-05-29
+  end_date: 2026-05-31
+  date_precision: year
+  url:
+  announced_on: 2025-03-12


### PR DESCRIPTION
Invalid date and website is still not ready (have to remove the website builder stuff generated by godaddy).
Kinda wasn't ready for adding the conference to this list yet, it is still a few months away, but we can keep this info.

Thanks!