### PR TITLE
RubyConf Austria: Show date.

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -3089,5 +3089,5 @@
   start_date: 2026-05-29
   end_date: 2026-05-31
   date_precision: year
-  url:
+  url: https://rubyconf.at
   announced_on: 2025-03-12

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -3075,15 +3075,6 @@
   mastodon: https://ruby.social/@rockymtnruby
   announced_on: 2024-10-08
 
-- name: RubyConf Austria 2025
-  location: Austria
-  # TODO: update when dates are confirmed
-  start_date: 2025-12-31
-  end_date: 2025-12-31
-  date_precision: year
-  url: https://rubyconf.at
-  announced_on: 2025-03-12
-
 - name: RubyConf TH 2026
   location: Bangkok, Thailand
   start_date: 2026-01-31
@@ -3091,3 +3082,12 @@
   url: https://rubyconfth.com
   twitter: rubyconfth
   announced_on: 2025-02-28
+
+- name: RubyConf Austria 2026
+  location: Vienna, Austria
+  # TODO: update when dates are confirmed
+  start_date: 2026-05-29
+  end_date: 2026-05-31
+  date_precision: year
+  url:
+  announced_on: 2025-03-12

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -3086,9 +3086,7 @@
 
 - name: RubyConf Austria 2026
   location: Vienna, Austria
-  # TODO: update when dates are confirmed
-  start_date: 2026-05-29
-  end_date: 2026-05-31
-  date_precision: year
+  start_date: 2026-05-30
+  end_date: 2026-05-30
   url: https://rubyconf.at
   announced_on: 2025-03-12


### PR DESCRIPTION
Just to show the proper date. The website now also has a coming soon page with some data at least. More to come soon on the website, the date is confirmed though.