### PR TITLE
Add North West Ruby User Group meetup

### DIFF
--- a/_data/meetup_groups.yml
+++ b/_data/meetup_groups.yml
@@ -424,6 +424,11 @@
   name: Newcastle Ruby
   service: meetupdotcom
 
+- id: nwrug
+  name: North West Ruby User Group
+  ical_url: https://nwrug.org/events.ics
+  timezone: Europe/London
+
 - id: nyc-on-rails
   name: NYC on Rails
   service: meetupdotcom


### PR DESCRIPTION
Operating out of Manchester, England, our website is over at https://nwrug.org.