### PR TITLE
Add RubyConf 2026

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -3175,7 +3175,7 @@
   start_date: 2026-12-31 # TODO: update once dates are confirmed
   end_date: 2026-12-31 # TODO: update once dates are confirmed
   announced_on: 2024-05-07
-  url: https://rubyconf.org
+  url: https://rubycentral.org/news/announcing-railsconf-2025-and-a-new-chapter-for-ruby-central-events
   twitter: rubyconf
   date_precision: year
   mastodon: https://ruby.social/@rubyconf

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -3169,3 +3169,13 @@
   twitter: helvetic_ruby
   date_precision: year
   mastodon: https://ruby.social/@helvetic_ruby
+
+- name: RubyConf 2026
+  location: United States # TODO: update once location is confirmed
+  start_date: 2026-12-31 # TODO: update once dates are confirmed
+  end_date: 2026-12-31 # TODO: update once dates are confirmed
+  announced_on: 2024-05-07
+  url: https://rubyconf.org
+  twitter: rubyconf
+  date_precision: year
+  mastodon: https://ruby.social/@rubyconf


### PR DESCRIPTION
https://rubycentral.org/news/announcing-railsconf-2025-and-a-new-chapter-for-ruby-central-events/