### PR TITLE
KCRuby is now on lu.ma

### DIFF
--- a/_data/meetup_groups.yml
+++ b/_data/meetup_groups.yml
@@ -293,7 +293,7 @@
 
 - id: kcruby
   name: Kansas City Ruby
-  service: meetupdotcom
+  service: luma
 
 # - id: kharkiv-rb
 #   name:

--- a/_data/meetup_groups.yml
+++ b/_data/meetup_groups.yml
@@ -293,7 +293,13 @@
 
 - id: kcruby
   name: Kansas City Ruby
+  service: meetupdotcom
+
+- id: kcruby
+  name: Kansas City Ruby
   service: luma
+  ical_url: https://api2.luma.com/ics/get?entity=calendar&id=cal-hlguC5XZPDfQzqv
+  timezone: America/Chicago
 
 # - id: kharkiv-rb
 #   name:


### PR DESCRIPTION
Update kcruby entry with luma as the service.

I'm one of the organizers of KC Ruby.

Our lu.ma profile is at https://luma.com/kcruby and you can check our site out at kcruby.org